### PR TITLE
Component loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Fix race condition in `BaseComponentCollection<T>` when multiple workers try to enqueue
   creates/updates/removes/unloads simultaneously (e.g. when multiple world segments are loaded in parallel
   by `Persistence`).
+* Refactor the component event APIs to distinguish between add/load similar to remove/unload. This is needed
+  to allow the persistence state trackers to ignore loaded components and avoid attempting to duplicate
+  components in the database.
 
 #### 14 January 2024
 

--- a/src/Client/ClientCore/Entities/ClientEntityBuilder.cs
+++ b/src/Client/ClientCore/Entities/ClientEntityBuilder.cs
@@ -33,7 +33,7 @@ public sealed class ClientEntityBuilder : AbstractEntityBuilder
     private readonly AnimatedSpriteComponentCollection animatedSprites;
     private readonly DrawableComponentCollection drawables;
 
-    public ClientEntityBuilder(ulong entityId,
+    public ClientEntityBuilder(ulong entityId, bool isLoad,
         EntityManager entityManager,
         PositionComponentCollection positions,
         VelocityComponentCollection velocities,
@@ -46,7 +46,7 @@ public sealed class ClientEntityBuilder : AbstractEntityBuilder
         NameComponentCollection names,
         ParentComponentCollection parents,
         EntityTable entityTable)
-        : base(entityId, entityManager, positions, velocities, materials,
+        : base(entityId, isLoad, entityManager, positions, velocities, materials,
             materialModifiers, aboveBlocks, playerCharacterTags, names, parents, entityTable)
     {
         this.drawables = drawables;
@@ -55,25 +55,25 @@ public sealed class ClientEntityBuilder : AbstractEntityBuilder
 
     public override IEntityBuilder Drawable()
     {
-        drawables.AddComponent(entityId, true);
+        drawables.AddComponent(entityId, true, load);
         return this;
     }
 
     public override IEntityBuilder WithoutDrawable()
     {
-        drawables.RemoveComponent(entityId);
+        drawables.RemoveComponent(entityId, load);
         return this;
     }
 
     public override IEntityBuilder AnimatedSprite(int animatedSpriteId)
     {
-        animatedSprites.AddComponent(entityId, animatedSpriteId);
+        animatedSprites.AddComponent(entityId, animatedSpriteId, load);
         return this;
     }
 
     public override IEntityBuilder WithoutAnimatedSprite()
     {
-        drawables.RemoveComponent(entityId);
+        drawables.RemoveComponent(entityId, load);
         return this;
     }
 

--- a/src/Client/ClientCore/Entities/ClientEntityFactory.cs
+++ b/src/Client/ClientCore/Entities/ClientEntityFactory.cs
@@ -77,9 +77,9 @@ public sealed class ClientEntityFactory : IEntityFactory
         return GetBuilder(assigner.GetNextId());
     }
 
-    public IEntityBuilder GetBuilder(ulong entityId)
+    public IEntityBuilder GetBuilder(ulong entityId, bool isLoad = false)
     {
-        return new ClientEntityBuilder(entityId,
+        return new ClientEntityBuilder(entityId, isLoad,
             entityManager, positions, velocities, drawables, materials,
             materialModifiers, aboveBlocks, animatedSprites, playerCharacterTags, names, parents, entityTable);
     }

--- a/src/Client/ClientCore/Systems/Block/Caches/BlockAnimatedSpriteCache.cs
+++ b/src/Client/ClientCore/Systems/Block/Caches/BlockAnimatedSpriteCache.cs
@@ -389,20 +389,33 @@ public sealed class BlockAnimatedSpriteCache : IBlockAnimatedSpriteCache, IDispo
     }
 
     /// <summary>
-    ///     Called when a component is added or modified.
+    ///     Called when a component is added.
     /// </summary>
     /// <param name="entityId">Block entity ID.</param>
     /// <param name="componentValue">Not used.</param>
-    private void OnComponentChanged(ulong entityId, int componentValue)
+    /// <param name="isLoad">Not used.</param>
+    private void OnComponentAdded(ulong entityId, int componentValue, bool isLoad)
     {
         changedBlocks.Add(entityId);
+    }
+
+    /// <summary>
+    ///     Called when a component is modified.
+    /// </summary>
+    /// <param name="entityId">Block entity ID.</param>
+    /// <param name="componentValue">Not used.</param>
+    private void OnComponentModified(ulong entityId, int componentValue)
+    {
+        // Treat it as an add.
+        OnComponentAdded(entityId, componentValue, false);
     }
 
     /// <summary>
     ///     Called when a component is removed.
     /// </summary>
     /// <param name="entityId">Block entity ID.</param>
-    private void OnComponentRemoved(ulong entityId)
+    /// <param name="isUnload">Not used.</param>
+    private void OnComponentRemoved(ulong entityId, bool isUnload)
     {
         removedBlocks.Add(entityId);
     }
@@ -412,9 +425,15 @@ public sealed class BlockAnimatedSpriteCache : IBlockAnimatedSpriteCache, IDispo
     /// </summary>
     /// <param name="entityId">Block entity ID.</param>
     /// <param name="componentValue">Not used.</param>
-    private void OnPositionChanged(ulong entityId, Vector3 componentValue)
+    /// <param name="isLoad">Not used.</param>
+    private void OnPositionAdded(ulong entityId, Vector3 componentValue, bool isLoad)
     {
-        OnComponentChanged(entityId, 0);
+        OnComponentModified(entityId, 0);
+    }
+
+    private void OnPositionModified(ulong entityId, Vector3 componentValue)
+    {
+        OnComponentModified(entityId, 0);
     }
 
     /// <summary>
@@ -423,22 +442,22 @@ public sealed class BlockAnimatedSpriteCache : IBlockAnimatedSpriteCache, IDispo
     private void RegisterEventHandlers()
     {
         materials.OnStartUpdates += OnStartUpdates;
-        materials.OnComponentAdded += OnComponentChanged;
-        materials.OnComponentModified += OnComponentChanged;
+        materials.OnComponentAdded += OnComponentAdded;
+        materials.OnComponentModified += OnComponentModified;
         materials.OnComponentRemoved += OnComponentRemoved;
         materials.OnEndUpdates += OnEndUpdates;
 
         materialModifiers.OnStartUpdates += OnStartUpdates;
-        materialModifiers.OnComponentAdded += OnComponentChanged;
-        materialModifiers.OnComponentModified += OnComponentChanged;
+        materialModifiers.OnComponentAdded += OnComponentAdded;
+        materialModifiers.OnComponentModified += OnComponentModified;
         materialModifiers.OnComponentRemoved += OnComponentRemoved;
         materialModifiers.OnEndUpdates += OnEndUpdates;
 
         positions.OnStartUpdates += OnStartUpdates;
         positions.OnEndUpdates += OnEndUpdates;
 
-        blockPositionEventFilter.OnComponentAdded += OnPositionChanged;
-        blockPositionEventFilter.OnComponentModified += OnPositionChanged;
+        blockPositionEventFilter.OnComponentAdded += OnPositionAdded;
+        blockPositionEventFilter.OnComponentModified += OnPositionModified;
 
         aboveBlocks.OnStartUpdates += OnStartUpdates;
         aboveBlocks.OnEndUpdates += OnEndUpdates;
@@ -450,22 +469,22 @@ public sealed class BlockAnimatedSpriteCache : IBlockAnimatedSpriteCache, IDispo
     private void DeregisterEventHandlers()
     {
         materials.OnStartUpdates -= OnStartUpdates;
-        materials.OnComponentAdded -= OnComponentChanged;
-        materials.OnComponentModified -= OnComponentChanged;
+        materials.OnComponentAdded -= OnComponentAdded;
+        materials.OnComponentModified -= OnComponentModified;
         materials.OnComponentRemoved -= OnComponentRemoved;
         materials.OnEndUpdates -= OnEndUpdates;
 
         materialModifiers.OnStartUpdates -= OnStartUpdates;
-        materialModifiers.OnComponentAdded -= OnComponentChanged;
-        materialModifiers.OnComponentModified -= OnComponentChanged;
+        materialModifiers.OnComponentAdded -= OnComponentAdded;
+        materialModifiers.OnComponentModified -= OnComponentModified;
         materialModifiers.OnComponentRemoved -= OnComponentRemoved;
         materialModifiers.OnEndUpdates -= OnEndUpdates;
 
         positions.OnStartUpdates -= OnStartUpdates;
         positions.OnEndUpdates -= OnEndUpdates;
 
-        blockPositionEventFilter.OnComponentAdded -= OnPositionChanged;
-        blockPositionEventFilter.OnComponentModified -= OnPositionChanged;
+        blockPositionEventFilter.OnComponentAdded -= OnPositionAdded;
+        blockPositionEventFilter.OnComponentModified -= OnPositionModified;
 
         aboveBlocks.OnStartUpdates -= OnStartUpdates;
         aboveBlocks.OnEndUpdates -= OnEndUpdates;

--- a/src/Common/EngineCore/Components/BaseComponentCollection.cs
+++ b/src/Common/EngineCore/Components/BaseComponentCollection.cs
@@ -292,12 +292,14 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
     /// <param name="newValue">New value.</param>
-    public void AddOrUpdateComponent(ulong entityId, T newValue)
+    /// <
+    /// <param name="isLoad">For adds, whether to treat as a load rather than an add.</param>
+    public void AddOrUpdateComponent(ulong entityId, T newValue, bool isLoad = false)
     {
         if (HasComponentForEntity(entityId))
             ModifyComponent(entityId, ComponentOperation.Set, newValue);
         else
-            AddComponent(entityId, newValue);
+            AddComponent(entityId, newValue, isLoad);
     }
 
     /// <summary>

--- a/src/Common/EngineCore/Components/BaseComponentCollection.cs
+++ b/src/Common/EngineCore/Components/BaseComponentCollection.cs
@@ -169,28 +169,13 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
 
     public event Action? OnStartUpdates;
 
-    public event ComponentEventDelegates<T>.ComponentEventHandler? OnComponentAdded;
+    public event ComponentEventDelegates<T>.ComponentAddedEventHandler? OnComponentAdded;
 
     public event ComponentEventDelegates<T>.ComponentRemovedEventHandler? OnComponentRemoved;
 
-    public event ComponentEventDelegates<T>.ComponentEventHandler? OnComponentModified;
+    public event ComponentEventDelegates<T>.ComponentModifiedEventHandler? OnComponentModified;
 
     public event Action? OnEndUpdates;
-
-    /// <summary>
-    ///     Applies pending component updates.
-    /// </summary>
-    public void ApplyComponentUpdates()
-    {
-        /* Apply all pending operations. */
-        ApplyReclaims();
-        ApplyAdds();
-        ApplyModifications();
-        ApplyRemoves();
-
-        /* Dispatch events as needed. */
-        FireComponentEvents();
-    }
 
     /// <summary>
     ///     Fully removes a component from the collection.
@@ -212,6 +197,21 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
         {
             pendingRemoves.Add(ref pendingRemove);
         }
+    }
+
+    /// <summary>
+    ///     Applies pending component updates.
+    /// </summary>
+    public void ApplyComponentUpdates()
+    {
+        /* Apply all pending operations. */
+        ApplyReclaims();
+        ApplyAdds();
+        ApplyModifications();
+        ApplyRemoves();
+
+        /* Dispatch events as needed. */
+        FireComponentEvents();
     }
 
     /// <summary>
@@ -477,7 +477,7 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
             {
                 /* Notify all listeners. */
                 var value = this[entityId];
-                OnComponentModified.Invoke(entityId, value, false);
+                OnComponentModified.Invoke(entityId, value);
             }
 
         /* Reset the pending events. */

--- a/src/Common/EngineCore/Components/BaseComponentCollection.cs
+++ b/src/Common/EngineCore/Components/BaseComponentCollection.cs
@@ -346,6 +346,19 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     }
 
     /// <summary>
+    ///     Gets a component, even if it was removed in the last tick.
+    /// </summary>
+    /// <param name="entityId">Entity ID.</param>
+    /// <returns>Component value.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown if no value is associated to the entity.</exception>
+    public T GetComponentWithLookback(ulong entityId)
+    {
+        if (entityToComponentMap.TryGetValue(entityId, out var componentId))
+            return components[componentId];
+        throw new KeyNotFoundException("No component for entity");
+    }
+
+    /// <summary>
     ///     Creates a dictionary mapping entity IDs to all known components.
     /// </summary>
     /// This method should be used sparingly - it requires allocation and creation of

--- a/src/Common/EngineCore/Components/BaseComponentCollection.cs
+++ b/src/Common/EngineCore/Components/BaseComponentCollection.cs
@@ -89,6 +89,11 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     private readonly StructBuffer<PendingAdd> pendingAdds = new(OperationBufferSize);
 
     /// <summary>
+    ///     Load events that are pending invocation.
+    /// </summary>
+    private readonly HashSet<ulong> pendingLoadEvents = new();
+
+    /// <summary>
     ///     Pending component modifications binned by operation.
     /// </summary>
     private readonly Dictionary<ComponentOperation, StructBuffer<PendingModify>>
@@ -118,11 +123,6 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     ///     Unload events that are pending invocation.
     /// </summary>
     private readonly HashSet<ulong> pendingUnloadEvents = new();
-
-    /// <summary>
-    ///     Pending component unloads.
-    /// </summary>
-    private readonly StructBuffer<PendingUnload> pendingUnloads = new(OperationBufferSize);
 
     /// <summary>
     ///     Creates a base component collection.
@@ -175,41 +175,7 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
 
     public event ComponentEventDelegates<T>.ComponentEventHandler? OnComponentModified;
 
-    public event ComponentEventDelegates<T>.ComponentUnloadedEventHandler? OnComponentUnloaded;
-
     public event Action? OnEndUpdates;
-
-    public void RemoveComponent(ulong entityId)
-    {
-        /* Ensure that a component is associated. */
-        if (!HasComponentForEntity(entityId)) return;
-
-        /* Enqueue the removal. */
-        var pendingRemove = new PendingRemove
-        {
-            EntityId = entityId
-        };
-        lock (pendingRemoves)
-        {
-            pendingRemoves.Add(ref pendingRemove);
-        }
-    }
-
-    public void UnloadComponent(ulong entityId)
-    {
-        /* Ensure that a component is associated. */
-        if (!HasComponentForEntity(entityId)) return;
-
-        /* Enqueue the unload. */
-        var pendingUnload = new PendingUnload
-        {
-            EntityId = entityId
-        };
-        lock (pendingUnloads)
-        {
-            pendingUnloads.Add(ref pendingUnload);
-        }
-    }
 
     /// <summary>
     ///     Applies pending component updates.
@@ -221,10 +187,31 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
         ApplyAdds();
         ApplyModifications();
         ApplyRemoves();
-        ApplyUnloads();
 
         /* Dispatch events as needed. */
         FireComponentEvents();
+    }
+
+    /// <summary>
+    ///     Fully removes a component from the collection.
+    /// </summary>
+    /// <param name="entityId">Entity ID whose component is to be removed.</param>
+    /// <param name="isUnload">If true, treat this as an unload rather than a full remove.</param>
+    public void RemoveComponent(ulong entityId, bool isUnload = false)
+    {
+        /* Ensure that a component is associated. */
+        if (!HasComponentForEntity(entityId)) return;
+
+        /* Enqueue the removal. */
+        var pendingRemove = new PendingRemove
+        {
+            EntityId = entityId,
+            IsUnload = isUnload
+        };
+        lock (pendingRemoves)
+        {
+            pendingRemoves.Add(ref pendingRemove);
+        }
     }
 
     /// <summary>
@@ -234,11 +221,12 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
     /// <param name="initialValue">Initial value of the component.</param>
+    /// <param name="isLoad">If true, treat the add as a load.</param>
     /// <exception cref="NotSupportedException">
     ///     Thrown if a component is already associated with the entity, and the
     ///     Set operation is not supported.
     /// </exception>
-    public void AddComponent(ulong entityId, T initialValue)
+    public void AddComponent(ulong entityId, T initialValue, bool isLoad = false)
     {
         if (HasComponentForEntity(entityId))
         {
@@ -253,7 +241,8 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
             var pendingAdd = new PendingAdd
             {
                 EntityId = entityId,
-                InitialValue = initialValue
+                InitialValue = initialValue,
+                IsLoad = isLoad
             };
             lock (pendingAdds)
             {
@@ -378,10 +367,9 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
         OnStartUpdates?.Invoke();
 
         /* Fire events. */
-        FireAddEvents();
+        FireAddAndLoadEvents();
         FireModificationEvents();
-        FireRemoveEvents();
-        FireUnloadEvents();
+        FireRemoveAndUnloadEvents();
 
         /* Announce that events are done being fired. */
         OnEndUpdates?.Invoke();
@@ -405,7 +393,10 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
         foreach (var pendingAdd in pendingAdds)
         {
             ApplyAddComponent(pendingAdd.EntityId, pendingAdd.InitialValue);
-            pendingAddEvents.Add(pendingAdd.EntityId);
+            if (pendingAdd.IsLoad)
+                pendingLoadEvents.Add(pendingAdd.EntityId);
+            else
+                pendingAddEvents.Add(pendingAdd.EntityId);
         }
 
         /* Reset the buffer. */
@@ -442,37 +433,34 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     private void ApplyRemoves()
     {
         /* Apply operations. */
-        foreach (var pendingRemove in pendingRemoves) ApplyRemoveOrUnloadComponent(pendingRemove.EntityId);
+        foreach (var pendingRemove in pendingRemoves)
+            ApplyRemoveOrUnloadComponent(pendingRemove.EntityId, pendingRemove.IsUnload);
 
         /* Clear the buffer. */
         pendingRemoves.Clear();
     }
 
     /// <summary>
-    ///     Applies all pending component unloads.
-    /// </summary>
-    private void ApplyUnloads()
-    {
-        /* Apply operations. */
-        foreach (var pendingUnload in pendingUnloads) ApplyRemoveOrUnloadComponent(pendingUnload.EntityId);
-
-        /* Clear the buffer. */
-        pendingUnloads.Clear();
-    }
-
-    /// <summary>
     ///     Fires events for component additions.
     /// </summary>
-    private void FireAddEvents()
+    private void FireAddAndLoadEvents()
     {
-        /* Iterate over entities that have been added. */
         if (OnComponentAdded != null)
+        {
+            // Adds.
             foreach (var entityId in pendingAddEvents)
             {
-                /* Notify all listeners. */
                 var value = this[entityId];
-                OnComponentAdded?.Invoke(entityId, value);
+                OnComponentAdded.Invoke(entityId, value, false);
             }
+
+            // Loads.
+            foreach (var entityId in pendingLoadEvents)
+            {
+                var value = this[entityId];
+                OnComponentAdded.Invoke(entityId, value, true);
+            }
+        }
 
         /* Reset the pending events. */
         pendingAddEvents.Clear();
@@ -489,7 +477,7 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
             {
                 /* Notify all listeners. */
                 var value = this[entityId];
-                OnComponentModified.Invoke(entityId, value);
+                OnComponentModified.Invoke(entityId, value, false);
             }
 
         /* Reset the pending events. */
@@ -499,30 +487,19 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     /// <summary>
     ///     Fires events for component removals.
     /// </summary>
-    private void FireRemoveEvents()
+    private void FireRemoveAndUnloadEvents()
     {
-        /* Iterate over entities that have been removed. */
         if (OnComponentRemoved != null)
-            foreach (var entityId in pendingRemoveEvents)
-                /* Notify all listeners. */
-                OnComponentRemoved.Invoke(entityId);
+        {
+            // Removes.
+            foreach (var entityId in pendingRemoveEvents) OnComponentRemoved.Invoke(entityId, false);
+
+            // Unloads.
+            foreach (var entityId in pendingUnloadEvents) OnComponentRemoved.Invoke(entityId, true);
+        }
 
         /* Reset the pending events. */
         pendingRemoveEvents.Clear();
-    }
-
-    /// <summary>
-    ///     Fires events for component unloads.
-    /// </summary>
-    private void FireUnloadEvents()
-    {
-        /* Iterate over entities that have been unloaded. */
-        if (OnComponentUnloaded != null)
-            foreach (var entityId in pendingUnloadEvents)
-                /* Notify all listeners. */
-                OnComponentUnloaded.Invoke(entityId);
-
-        /* Reset the pending events. */
         pendingUnloadEvents.Clear();
     }
 
@@ -546,9 +523,15 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     ///     the value may be referenced from code triggered by remove/unload delegates.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
-    private void ApplyRemoveOrUnloadComponent(ulong entityId)
+    /// <param name="isUnload">If true, treat as unload.</param>
+    private void ApplyRemoveOrUnloadComponent(ulong entityId, bool isUnload)
     {
         if (!entityToComponentMap.ContainsKey(entityId)) return;
+        if (isUnload)
+            pendingUnloadEvents.Add(entityId);
+        else
+            pendingRemoveEvents.Add(entityId);
+
         pendingReclaims.Add(entityId);
     }
 
@@ -645,6 +628,11 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
         ///     Initial value of the new component.
         /// </summary>
         public T InitialValue;
+
+        /// <summary>
+        ///     Whether this add is a load.
+        /// </summary>
+        public bool IsLoad;
     }
 
     /// <summary>
@@ -657,14 +645,10 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
         ///     ID of the associated entity.
         /// </summary>
         public ulong EntityId;
-    }
 
-    [DebuggerDisplay("{EntityId}")]
-    private struct PendingUnload
-    {
         /// <summary>
-        ///     ID of the associated entity.
+        ///     Whether this remove is an unload.
         /// </summary>
-        public ulong EntityId;
+        public bool IsUnload;
     }
 }

--- a/src/Common/EngineCore/Components/BaseComponentCollection.cs
+++ b/src/Common/EngineCore/Components/BaseComponentCollection.cs
@@ -479,6 +479,7 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
 
         /* Reset the pending events. */
         pendingAddEvents.Clear();
+        pendingLoadEvents.Clear();
     }
 
     /// <summary>

--- a/src/Common/EngineCore/Components/BaseTagCollection.cs
+++ b/src/Common/EngineCore/Components/BaseTagCollection.cs
@@ -69,17 +69,19 @@ public class BaseTagCollection : BaseComponentCollection<bool>
     ///     Sets a tag on the given entity.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
-    public void TagEntity(ulong entityId)
+    /// <param name="isLoad">Whether to treat as a load instead of an add.</param>
+    public void TagEntity(ulong entityId, bool isLoad = false)
     {
-        if (!HasTagForEntity(entityId)) AddComponent(entityId, true);
+        if (!HasTagForEntity(entityId)) AddComponent(entityId, true, isLoad);
     }
 
     /// <summary>
     ///     Removes a tag from the given entity. If the entity is not tagged, this method silently fails.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
-    public void UntagEntity(ulong entityId)
+    /// <param name="isUnload">Whether to treat as an unload isntead of a remove.</param>
+    public void UntagEntity(ulong entityId, bool isUnload = false)
     {
-        if (HasTagForEntity(entityId)) RemoveComponent(entityId);
+        if (HasTagForEntity(entityId)) RemoveComponent(entityId, isUnload);
     }
 }

--- a/src/Common/EngineCore/Components/ComponentEventDelegates.cs
+++ b/src/Common/EngineCore/Components/ComponentEventDelegates.cs
@@ -24,15 +24,22 @@ namespace Sovereign.EngineCore.Components;
 public static class ComponentEventDelegates<T>
 {
     /// <summary>
-    ///     Delegate type used to communicate component add and update events.
+    ///     Delegate type used to communicate component add and load events.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
     /// <param name="componentValue">New component value.</param>
     /// <param name="isLoad">Whether this action is a load (true), or a new change (false).</param>
-    public delegate void ComponentEventHandler(ulong entityId, T componentValue, bool isLoad);
+    public delegate void ComponentAddedEventHandler(ulong entityId, T componentValue, bool isLoad);
 
     /// <summary>
-    ///     Delegate type used to communicate component remove events.
+    ///     Delegate type used to communicate component update events.
+    /// </summary>
+    /// <param name="entityId">Entity ID.</param>
+    /// <param name="componentValue">New component value.</param>
+    public delegate void ComponentModifiedEventHandler(ulong entityId, T componentValue);
+
+    /// <summary>
+    ///     Delegate type used to communicate component remove and unload events.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
     /// <param name="isUnload">Whether this action is an unload (true), or a full deletion (false).</param>

--- a/src/Common/EngineCore/Components/ComponentEventDelegates.cs
+++ b/src/Common/EngineCore/Components/ComponentEventDelegates.cs
@@ -28,17 +28,13 @@ public static class ComponentEventDelegates<T>
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
     /// <param name="componentValue">New component value.</param>
-    public delegate void ComponentEventHandler(ulong entityId, T componentValue);
+    /// <param name="isLoad">Whether this action is a load (true), or a new change (false).</param>
+    public delegate void ComponentEventHandler(ulong entityId, T componentValue, bool isLoad);
 
     /// <summary>
     ///     Delegate type used to communicate component remove events.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
-    public delegate void ComponentRemovedEventHandler(ulong entityId);
-
-    /// <summary>
-    ///     Delegate type used to communicate component unload events.
-    /// </summary>
-    /// <param name="entityId"></param>
-    public delegate void ComponentUnloadedEventHandler(ulong entityId);
+    /// <param name="isUnload">Whether this action is an unload (true), or a full deletion (false).</param>
+    public delegate void ComponentRemovedEventHandler(ulong entityId, bool isUnload);
 }

--- a/src/Common/EngineCore/Components/ComponentManager.cs
+++ b/src/Common/EngineCore/Components/ComponentManager.cs
@@ -71,7 +71,7 @@ public class ComponentManager
     /// <param name="entityId">Entity ID.</param>
     public void RemoveAllComponentsForEntity(ulong entityId)
     {
-        foreach (var remover in componentRemovers) remover.RemoveComponent(entityId);
+        foreach (var remover in componentRemovers) remover.RemoveComponent(entityId, false);
     }
 
     /// <summary>
@@ -81,6 +81,7 @@ public class ComponentManager
     /// <param name="entityId">Entity ID.</param>
     public void UnloadAllComponentsForEntity(ulong entityId)
     {
+        foreach (var remover in componentRemovers) remover.RemoveComponent(entityId, true);
     }
 
     /// <summary>

--- a/src/Common/EngineCore/Components/IComponentEventSource.cs
+++ b/src/Common/EngineCore/Components/IComponentEventSource.cs
@@ -37,14 +37,14 @@ public interface IComponentEventSource<T>
     /// </summary>
     /// This is intended for use with data view objects that are updated
     /// on the main thread once component updates for a given tick are complete.
-    event ComponentEventDelegates<T>.ComponentEventHandler? OnComponentAdded;
+    event ComponentEventDelegates<T>.ComponentAddedEventHandler? OnComponentAdded;
 
     /// <summary>
     ///     Event triggered when an existing component is updated.
     /// </summary>
     /// This is intended for use with data view objects that are updated
     /// on the main thread once component updates for a given tick are complete.
-    event ComponentEventDelegates<T>.ComponentEventHandler? OnComponentModified;
+    event ComponentEventDelegates<T>.ComponentModifiedEventHandler? OnComponentModified;
 
     /// <summary>
     ///     Event triggered when a component is removed from the collection.

--- a/src/Common/EngineCore/Components/IComponentEventSource.cs
+++ b/src/Common/EngineCore/Components/IComponentEventSource.cs
@@ -40,13 +40,6 @@ public interface IComponentEventSource<T>
     event ComponentEventDelegates<T>.ComponentEventHandler? OnComponentAdded;
 
     /// <summary>
-    ///     Event triggered when a component is removed from the collection.
-    /// </summary>
-    /// This is intended for use with data view objects that are updated
-    /// on the main thread once component updates for a given tick are complete.
-    event ComponentEventDelegates<T>.ComponentRemovedEventHandler? OnComponentRemoved;
-
-    /// <summary>
     ///     Event triggered when an existing component is updated.
     /// </summary>
     /// This is intended for use with data view objects that are updated
@@ -54,9 +47,11 @@ public interface IComponentEventSource<T>
     event ComponentEventDelegates<T>.ComponentEventHandler? OnComponentModified;
 
     /// <summary>
-    ///     Event triggered when an existing component is unloaded from memory.
+    ///     Event triggered when a component is removed from the collection.
     /// </summary>
-    event ComponentEventDelegates<T>.ComponentUnloadedEventHandler? OnComponentUnloaded;
+    /// This is intended for use with data view objects that are updated
+    /// on the main thread once component updates for a given tick are complete.
+    event ComponentEventDelegates<T>.ComponentRemovedEventHandler? OnComponentRemoved;
 
     /// <summary>
     ///     Event triggered when component updates are complete.

--- a/src/Common/EngineCore/Components/IComponentRemover.cs
+++ b/src/Common/EngineCore/Components/IComponentRemover.cs
@@ -27,12 +27,6 @@ public interface IComponentRemover
     ///     If no entity is associated with the given entity, no action is performed.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
-    void RemoveComponent(ulong entityId);
-
-    /// <summary>
-    ///     Enqueues the unloading of the component associated with the given entity ID.
-    ///     If no entity is associated with the given entity, no action is performed.
-    /// </summary>
-    /// <param name="entityId">Entity ID.</param>
-    void UnloadComponent(ulong entityId);
+    /// <param name="isUnload">If true, treat as an unload rather than a remove.</param>
+    void RemoveComponent(ulong entityId, bool isUnload);
 }

--- a/src/Common/EngineCore/Components/Indexers/BaseComponentEventFilter.cs
+++ b/src/Common/EngineCore/Components/Indexers/BaseComponentEventFilter.cs
@@ -31,10 +31,9 @@ public abstract class BaseComponentEventFilter<T> : BaseComponentIndexer<T>, ICo
     }
 
     public event Action? OnStartUpdates;
-    public event ComponentEventDelegates<T>.ComponentEventHandler? OnComponentAdded;
+    public event ComponentEventDelegates<T>.ComponentAddedEventHandler? OnComponentAdded;
     public event ComponentEventDelegates<T>.ComponentRemovedEventHandler? OnComponentRemoved;
-    public event ComponentEventDelegates<T>.ComponentEventHandler? OnComponentModified;
-    public event ComponentEventDelegates<T>.ComponentUnloadedEventHandler? OnComponentUnloaded;
+    public event ComponentEventDelegates<T>.ComponentModifiedEventHandler? OnComponentModified;
     public event Action? OnEndUpdates;
 
     /// <summary>
@@ -54,9 +53,9 @@ public abstract class BaseComponentEventFilter<T> : BaseComponentIndexer<T>, ICo
         OnEndUpdates?.Invoke();
     }
 
-    protected override void ComponentAddedCallback(ulong entityId, T componentValue)
+    protected override void ComponentAddedCallback(ulong entityId, T componentValue, bool isLoad)
     {
-        if (ShouldAccept(entityId)) OnComponentAdded?.Invoke(entityId, componentValue);
+        if (ShouldAccept(entityId)) OnComponentAdded?.Invoke(entityId, componentValue, isLoad);
     }
 
     protected override void ComponentModifiedCallback(ulong entityId, T componentValue)
@@ -64,13 +63,8 @@ public abstract class BaseComponentEventFilter<T> : BaseComponentIndexer<T>, ICo
         if (ShouldAccept(entityId)) OnComponentModified?.Invoke(entityId, componentValue);
     }
 
-    protected override void ComponentRemovedCallback(ulong entityId)
+    protected override void ComponentRemovedCallback(ulong entityId, bool isUnload)
     {
-        if (ShouldAccept(entityId)) OnComponentRemoved?.Invoke(entityId);
-    }
-
-    protected override void ComponentUnloadedCallback(ulong entityId)
-    {
-        if (ShouldAccept(entityId)) OnComponentUnloaded?.Invoke(entityId);
+        if (ShouldAccept(entityId)) OnComponentRemoved?.Invoke(entityId, isUnload);
     }
 }

--- a/src/Common/EngineCore/Components/Indexers/BaseComponentIndexer.cs
+++ b/src/Common/EngineCore/Components/Indexers/BaseComponentIndexer.cs
@@ -39,14 +39,12 @@ public class BaseComponentIndexer<T> : IDisposable
         eventSource.OnComponentAdded += ComponentAddedCallback;
         eventSource.OnComponentModified += ComponentModifiedCallback;
         eventSource.OnComponentRemoved += ComponentRemovedCallback;
-        eventSource.OnComponentUnloaded += ComponentUnloadedCallback;
         eventSource.OnEndUpdates += EndUpdatesCallback;
     }
 
     public void Dispose()
     {
         eventSource.OnEndUpdates -= EndUpdatesCallback;
-        eventSource.OnComponentUnloaded -= ComponentUnloadedCallback;
         eventSource.OnComponentRemoved -= ComponentRemovedCallback;
         eventSource.OnComponentModified -= ComponentModifiedCallback;
         eventSource.OnComponentAdded -= ComponentAddedCallback;
@@ -67,7 +65,8 @@ public class BaseComponentIndexer<T> : IDisposable
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
     /// <param name="componentValue">New component value.</param>
-    protected virtual void ComponentAddedCallback(ulong entityId, T componentValue)
+    /// <param name="isLoad">If true, indicates the component was loaded rather than added.</param>
+    protected virtual void ComponentAddedCallback(ulong entityId, T componentValue, bool isLoad)
     {
     }
 
@@ -86,16 +85,8 @@ public class BaseComponentIndexer<T> : IDisposable
     ///     Defaults to no action.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
-    protected virtual void ComponentRemovedCallback(ulong entityId)
-    {
-    }
-
-    /// <summary>
-    ///     Called when the event source signals that a component is unloaded.
-    ///     Defaults to no action.
-    /// </summary>
-    /// <param name="entityId">Entity ID.</param>
-    protected virtual void ComponentUnloadedCallback(ulong entityId)
+    /// <param name="isUnload">If true, indicates the component was unloaded rather than removed.</param>
+    protected virtual void ComponentRemovedCallback(ulong entityId, bool isUnload)
     {
     }
 

--- a/src/Common/EngineCore/Components/Indexers/BaseComponentReducer.cs
+++ b/src/Common/EngineCore/Components/Indexers/BaseComponentReducer.cs
@@ -45,7 +45,7 @@ public abstract class BaseComponentReducer<T> : BaseComponentIndexer<T> where T 
         this.eventSender = eventSender;
     }
 
-    protected override void ComponentAddedCallback(ulong entityId, T componentValue)
+    protected override void ComponentAddedCallback(ulong entityId, T componentValue, bool isLoad)
     {
         entityIds.Add(entityId);
     }

--- a/src/Common/EngineCore/Components/Indexers/BaseGridPositionIndexer.cs
+++ b/src/Common/EngineCore/Components/Indexers/BaseGridPositionIndexer.cs
@@ -50,7 +50,7 @@ public class BaseGridPositionIndexer : BaseComponentIndexer<Vector3>
             : null;
     }
 
-    protected override void ComponentAddedCallback(ulong entityId, Vector3 componentValue)
+    protected override void ComponentAddedCallback(ulong entityId, Vector3 componentValue, bool isLoad)
     {
         AddEntity(entityId, componentValue);
     }
@@ -61,12 +61,7 @@ public class BaseGridPositionIndexer : BaseComponentIndexer<Vector3>
         AddEntity(entityId, componentValue);
     }
 
-    protected override void ComponentRemovedCallback(ulong entityId)
-    {
-        RemoveEntity(entityId);
-    }
-
-    protected override void ComponentUnloadedCallback(ulong entityId)
+    protected override void ComponentRemovedCallback(ulong entityId, bool isUnload)
     {
         RemoveEntity(entityId);
     }

--- a/src/Common/EngineCore/Components/Indexers/BasePositionComponentIndexer.cs
+++ b/src/Common/EngineCore/Components/Indexers/BasePositionComponentIndexer.cs
@@ -103,7 +103,7 @@ public class BasePositionComponentIndexer : BaseComponentIndexer<Vector3>
         updateLock = AcquireLock();
     }
 
-    protected override void ComponentAddedCallback(ulong entityId, Vector3 position)
+    protected override void ComponentAddedCallback(ulong entityId, Vector3 position, bool isLoad)
     {
         if (updateLock == null) return;
         octree.Add(updateLock.octreeLock, position, entityId);
@@ -115,13 +115,7 @@ public class BasePositionComponentIndexer : BaseComponentIndexer<Vector3>
         octree.UpdatePosition(updateLock.octreeLock, entityId, position);
     }
 
-    protected override void ComponentRemovedCallback(ulong entityId)
-    {
-        if (updateLock == null) return;
-        octree.Remove(updateLock.octreeLock, entityId);
-    }
-
-    protected override void ComponentUnloadedCallback(ulong entityId)
+    protected override void ComponentRemovedCallback(ulong entityId, bool isUnload)
     {
         if (updateLock == null) return;
         octree.Remove(updateLock.octreeLock, entityId);

--- a/src/Common/EngineCore/Components/Indexers/EntityHierarchyIndexer.cs
+++ b/src/Common/EngineCore/Components/Indexers/EntityHierarchyIndexer.cs
@@ -83,7 +83,7 @@ public class EntityHierarchyIndexer : BaseComponentIndexer<ulong>
         return new HashSet<ulong>();
     }
 
-    protected override void ComponentAddedCallback(ulong entityId, ulong parentId)
+    protected override void ComponentAddedCallback(ulong entityId, ulong parentId, bool isLoad)
     {
         AddEntity(entityId, parentId);
     }
@@ -96,12 +96,7 @@ public class EntityHierarchyIndexer : BaseComponentIndexer<ulong>
         AddEntity(entityId, parentId);
     }
 
-    protected override void ComponentRemovedCallback(ulong entityId)
-    {
-        RemoveEntity(entityId);
-    }
-
-    protected override void ComponentUnloadedCallback(ulong entityId)
+    protected override void ComponentRemovedCallback(ulong entityId, bool isUnload)
     {
         RemoveEntity(entityId);
     }
@@ -158,10 +153,7 @@ public class EntityHierarchyIndexer : BaseComponentIndexer<ulong>
         while (trackedParent.TryGetValue(parentId, out parentId))
         {
             allDescendants[parentId].Remove(entityId);
-            foreach (var childId in childSpan)
-            {
-                allDescendants[parentId].Remove(childId);
-            }
+            foreach (var childId in childSpan) allDescendants[parentId].Remove(childId);
         }
 
         trackedParent.Remove(entityId, out _);

--- a/src/Common/EngineCore/Entities/AbstractEntityBuilder.cs
+++ b/src/Common/EngineCore/Entities/AbstractEntityBuilder.cs
@@ -35,6 +35,7 @@ public abstract class AbstractEntityBuilder : IEntityBuilder, IDisposable
 
     protected readonly ulong entityId;
     private readonly EntityTable entityTable;
+    protected readonly bool load;
     protected readonly MaterialModifierComponentCollection materialModifiers;
     protected readonly MaterialComponentCollection materials;
     protected readonly NameComponentCollection names;
@@ -45,7 +46,7 @@ public abstract class AbstractEntityBuilder : IEntityBuilder, IDisposable
 
     private readonly IncrementalGuard.IncrementalGuardWeakLock weakLock;
 
-    protected AbstractEntityBuilder(ulong entityId,
+    protected AbstractEntityBuilder(ulong entityId, bool load,
         EntityManager entityManager, PositionComponentCollection positions,
         VelocityComponentCollection velocities, MaterialComponentCollection materials,
         MaterialModifierComponentCollection materialModifiers,
@@ -56,6 +57,7 @@ public abstract class AbstractEntityBuilder : IEntityBuilder, IDisposable
         EntityTable entityTable)
     {
         this.entityId = entityId;
+        this.load = load;
         this.positions = positions;
         this.velocities = velocities;
         this.materials = materials;
@@ -84,8 +86,8 @@ public abstract class AbstractEntityBuilder : IEntityBuilder, IDisposable
 
     public IEntityBuilder Positionable(Vector3 position, Vector3 velocity)
     {
-        positions.AddOrUpdateComponent(entityId, position);
-        velocities.AddOrUpdateComponent(entityId, velocity);
+        positions.AddOrUpdateComponent(entityId, position, load);
+        velocities.AddOrUpdateComponent(entityId, velocity, load);
         return this;
     }
 
@@ -101,15 +103,15 @@ public abstract class AbstractEntityBuilder : IEntityBuilder, IDisposable
 
     public IEntityBuilder WithoutPositionable()
     {
-        positions.RemoveComponent(entityId);
-        velocities.RemoveComponent(entityId);
+        positions.RemoveComponent(entityId, load);
+        velocities.RemoveComponent(entityId, load);
         return this;
     }
 
     public IEntityBuilder Material(int materialId, int materialModifier)
     {
-        materials.AddOrUpdateComponent(entityId, materialId);
-        materialModifiers.AddOrUpdateComponent(entityId, materialModifier);
+        materials.AddOrUpdateComponent(entityId, materialId, load);
+        materialModifiers.AddOrUpdateComponent(entityId, materialModifier, load);
         return this;
     }
 
@@ -120,56 +122,56 @@ public abstract class AbstractEntityBuilder : IEntityBuilder, IDisposable
 
     public IEntityBuilder WithoutMaterial()
     {
-        materials.RemoveComponent(entityId);
-        materialModifiers.RemoveComponent(entityId);
+        materials.RemoveComponent(entityId, load);
+        materialModifiers.RemoveComponent(entityId, load);
         return this;
     }
 
     public IEntityBuilder AboveBlock(ulong otherEntityId)
     {
-        aboveBlocks.AddOrUpdateComponent(entityId, otherEntityId);
+        aboveBlocks.AddOrUpdateComponent(entityId, otherEntityId, load);
         return this;
     }
 
     public IEntityBuilder WithoutAboveBlock()
     {
-        aboveBlocks.RemoveComponent(entityId);
+        aboveBlocks.RemoveComponent(entityId, load);
         return this;
     }
 
     public IEntityBuilder PlayerCharacter()
     {
-        playerCharacterTags.TagEntity(entityId);
+        playerCharacterTags.TagEntity(entityId, load);
         return this;
     }
 
     public IEntityBuilder WithoutPlayerCharacter()
     {
-        playerCharacterTags.UntagEntity(entityId);
+        playerCharacterTags.UntagEntity(entityId, load);
         return this;
     }
 
     public IEntityBuilder Name(string name)
     {
-        names.AddOrUpdateComponent(entityId, name);
+        names.AddOrUpdateComponent(entityId, name, load);
         return this;
     }
 
     public IEntityBuilder WithoutName()
     {
-        names.RemoveComponent(entityId);
+        names.RemoveComponent(entityId, load);
         return this;
     }
 
     public IEntityBuilder Parent(ulong parentEntityId)
     {
-        parents.AddOrUpdateComponent(entityId, parentEntityId);
+        parents.AddOrUpdateComponent(entityId, parentEntityId, load);
         return this;
     }
 
     public IEntityBuilder WithoutParent()
     {
-        parents.RemoveComponent(entityId);
+        parents.RemoveComponent(entityId, load);
         return this;
     }
 

--- a/src/Common/EngineCore/Entities/IEntityFactory.cs
+++ b/src/Common/EngineCore/Entities/IEntityFactory.cs
@@ -32,6 +32,7 @@ public interface IEntityFactory
     ///     Gets an entity builder for the given entity ID.
     /// </summary>
     /// <param name="entityId">Entity ID for the new entity.</param>
+    /// <param name="load">If true, loads rather than creates the entity.</param>
     /// <returns>Entity builder.</returns>
-    IEntityBuilder GetBuilder(ulong entityId);
+    IEntityBuilder GetBuilder(ulong entityId, bool load = false);
 }

--- a/src/Common/EngineCore/Systems/WorldManagement/Components/Indexers/NonBlockWorldSegmentIndexer.cs
+++ b/src/Common/EngineCore/Systems/WorldManagement/Components/Indexers/NonBlockWorldSegmentIndexer.cs
@@ -69,7 +69,7 @@ public class NonBlockWorldSegmentIndexer : BaseComponentIndexer<Vector3>
         return new HashSet<ulong>(index[segmentIndex]);
     }
 
-    protected override void ComponentAddedCallback(ulong entityId, Vector3 componentValue)
+    protected override void ComponentAddedCallback(ulong entityId, Vector3 componentValue, bool isLoad)
     {
         AddEntity(entityId, componentValue);
     }
@@ -85,12 +85,7 @@ public class NonBlockWorldSegmentIndexer : BaseComponentIndexer<Vector3>
         }
     }
 
-    protected override void ComponentRemovedCallback(ulong entityId)
-    {
-        RemoveEntity(entityId);
-    }
-
-    protected override void ComponentUnloadedCallback(ulong entityId)
+    protected override void ComponentRemovedCallback(ulong entityId, bool isUnload)
     {
         RemoveEntity(entityId);
     }

--- a/src/Common/EngineUtil/Collections/Octree/OctreeNode.cs
+++ b/src/Common/EngineUtil/Collections/Octree/OctreeNode.cs
@@ -52,6 +52,8 @@ internal sealed class OctreeNode<T> where T : notnull
     /// </summary>
     public readonly Vector3 minPosition;
 
+    private readonly Stack<OctreeNode<T>> nodesToVisit = new(16);
+
     /// <summary>
     ///     Octree to which this node belongs.
     /// </summary>
@@ -248,7 +250,7 @@ internal sealed class OctreeNode<T> where T : notnull
     private void RebalanceLeafNode()
     {
         /* Depth-first search through the leaf nodes. */
-        var nodesToVisit = new Stack<OctreeNode<T>>();
+        nodesToVisit.Clear();
         nodesToVisit.Push(this);
         while (nodesToVisit.Count > 0)
         {

--- a/src/Server/Persistence/Entities/EntityProcessor.cs
+++ b/src/Server/Persistence/Entities/EntityProcessor.cs
@@ -68,8 +68,8 @@ public sealed class EntityProcessor
         /* Get the entity ID. */
         var entityId = (ulong)reader.GetInt64(INDEX_ID);
 
-        /* Start creating the entity. */
-        var builder = entityFactory.GetBuilder(entityId);
+        /* Start loading the entity. */
+        var builder = entityFactory.GetBuilder(entityId, true);
 
         /* Process components. */
         ProcessPosition(reader, builder);

--- a/src/Server/Persistence/State/BaseStateTracker.cs
+++ b/src/Server/Persistence/State/BaseStateTracker.cs
@@ -68,8 +68,12 @@ public abstract class BaseStateTracker<T> : IDisposable
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
     /// <param name="componentValue">Component value.</param>
-    private void OnComponentAdded(ulong entityId, T componentValue)
+    /// <param name="isLoad">If true, this is a loaded component that should not be re-added to the database.</param>
+    private void OnComponentAdded(ulong entityId, T componentValue, bool isLoad)
     {
+        // Skip component loads - these are already in the database (that's where they were loaded from).
+        if (isLoad) return;
+
         /* Map the entity ID. */
         var persistedId = GetPersistedId(entityId);
 
@@ -107,8 +111,12 @@ public abstract class BaseStateTracker<T> : IDisposable
     ///     Called when a component is removed.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
-    private void OnComponentRemoved(ulong entityId)
+    /// <param name="isUnload">If true, this is just an unload from memory - do not modify the database.</param>
+    private void OnComponentRemoved(ulong entityId, bool isUnload)
     {
+        // Skip unloads.
+        if (isUnload) return;
+
         /* Map the entity ID. */
         var persistedId = GetPersistedId(entityId);
 

--- a/src/Server/ServerCore/Entities/ServerEntityBuilder.cs
+++ b/src/Server/ServerCore/Entities/ServerEntityBuilder.cs
@@ -32,7 +32,7 @@ public sealed class ServerEntityBuilder : AbstractEntityBuilder
 {
     private readonly AccountComponentCollection accounts;
 
-    public ServerEntityBuilder(ulong entityId,
+    public ServerEntityBuilder(ulong entityId, bool load,
         EntityManager entityManager,
         PositionComponentCollection positions,
         VelocityComponentCollection velocities,
@@ -44,7 +44,7 @@ public sealed class ServerEntityBuilder : AbstractEntityBuilder
         AccountComponentCollection accounts,
         ParentComponentCollection parents,
         EntityTable entityTable)
-        : base(entityId, entityManager, positions, velocities, materials,
+        : base(entityId, load, entityManager, positions, velocities, materials,
             materialModifiers, aboveBlocks, playerCharacterTags, names, parents, entityTable)
     {
         this.accounts = accounts;
@@ -76,13 +76,13 @@ public sealed class ServerEntityBuilder : AbstractEntityBuilder
 
     public override IEntityBuilder Account(Guid accountId)
     {
-        accounts.AddComponent(entityId, accountId);
+        accounts.AddComponent(entityId, accountId, load);
         return this;
     }
 
     public override IEntityBuilder WithoutAccount()
     {
-        accounts.RemoveComponent(entityId);
+        accounts.RemoveComponent(entityId, load);
         return this;
     }
 }

--- a/src/Server/ServerCore/Entities/ServerEntityFactory.cs
+++ b/src/Server/ServerCore/Entities/ServerEntityFactory.cs
@@ -75,10 +75,11 @@ public sealed class ServerEntityFactory : IEntityFactory
         return GetBuilder(entityAssigner.GetNextId());
     }
 
-    public IEntityBuilder GetBuilder(ulong entityId)
+    public IEntityBuilder GetBuilder(ulong entityId, bool load = false)
     {
         return new ServerEntityBuilder(
             entityId,
+            load,
             entityManager,
             positions,
             velocities,

--- a/src/Server/ServerCore/Systems/WorldManagement/WorldSegmentBlockDataManager.cs
+++ b/src/Server/ServerCore/Systems/WorldManagement/WorldSegmentBlockDataManager.cs
@@ -197,15 +197,15 @@ public sealed class WorldSegmentBlockDataManager
     /// <param name="isUnload">Unused.</param>
     private void ScheduleFromBlock(ulong entityId, bool isUnload)
     {
-        var lastPosition = positions.GetComponentForEntity(entityId, true);
-        if (lastPosition.HasValue)
+        try
         {
-            var segmentIndex = resolver.GetWorldSegmentForPosition(lastPosition.Value);
+            var lastPosition = positions.GetComponentWithLookback(entityId);
+            var segmentIndex = resolver.GetWorldSegmentForPosition(lastPosition);
             segmentsToRegenerate.Add(segmentIndex);
         }
-        else
+        catch (Exception e)
         {
-            Logger.ErrorFormat("Could not resolve position of removed block {0}.", entityId);
+            Logger.ErrorFormat(e, "Could not schedule block for entity {0}.", entityId);
         }
     }
 


### PR DESCRIPTION
In `BaseComponentCollection<T>`, separately track component loads from component adds. Update the persistence state trackers to ignore any component load events, since otherwise the persistence system will try to recreate existing components in the database. Also fix up some memory allocation performance issues along the way.