### PR TITLE
Server player limit setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2026
 
+### September
+
+#### 3 September 2026
+
+* Add a server option to limit the number of concurrently connected players.
+
 ### April
 
 #### 12 April 2026

--- a/docs/manual/creators/config/index.md
+++ b/docs/manual/creators/config/index.md
@@ -84,6 +84,7 @@ interpolating the two steps around the point in time.
 - **LoginDenialPeriodSeconds**: The duration in seconds for which login is denied when the account is locked.
 - **MinimumPasswordLength**: The minimum length for user passwords.
 - **HandoffPeriodSeconds**: The duration in seconds for handoff operations.
+- **MaxPlayers**: The maximum number of concurrently connected players. A value of 0 (the default) means no limit.
 
 ### ScriptingOptions
 - **ScriptDirectory**: The directory where scripts are stored.

--- a/src/Client/ClientCore/Network/Infrastructure/AuthenticationClient.cs
+++ b/src/Client/ClientCore/Network/Infrastructure/AuthenticationClient.cs
@@ -118,6 +118,13 @@ public sealed class AuthenticationClient
                     result = new Option<LoginResponse, string>(serverError);
                     break;
 
+                case HttpStatusCode.ServiceUnavailable:
+                    // Failed: Server is at capacity.
+                    const string serverAtCapacity = "Login failed: server is at capacity, try again later.";
+                    logger.LogError(serverAtCapacity);
+                    result = new Option<LoginResponse, string>(serverAtCapacity);
+                    break;
+
                 default:
                     // Failed: Unknown error.
                     const string unknownError = "Login failed: unknown error.";

--- a/src/Server/Accounts/Accounts/Authentication/AccountLoginTracker.cs
+++ b/src/Server/Accounts/Accounts/Authentication/AccountLoginTracker.cs
@@ -155,6 +155,11 @@ public sealed class AccountLoginTracker
     }
 
     /// <summary>
+    ///     Gets the number of accounts currently logged in.
+    /// </summary>
+    public int LoggedInAccountCount => accountLoginStates.Count;
+
+    /// <summary>
     ///     Gets the login state of the given account ID.
     /// </summary>
     /// <param name="accountId">Account ID.</param>

--- a/src/Server/Accounts/Accounts/Services/AccountServices.cs
+++ b/src/Server/Accounts/Accounts/Services/AccountServices.cs
@@ -17,9 +17,11 @@
 
 using System;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Sovereign.Accounts.Accounts.Authentication;
 using Sovereign.Accounts.Accounts.Registration;
 using Sovereign.EngineUtil.Monads;
+using Sovereign.ServerCore.Configuration;
 
 namespace Sovereign.Accounts.Accounts.Services;
 
@@ -29,6 +31,7 @@ namespace Sovereign.Accounts.Accounts.Services;
 public sealed class AccountServices
 {
     private readonly AccountAuthenticator authenticator;
+    private readonly AccountsOptions config;
     private readonly AuthenticationAttemptLimiter limiter;
     private readonly ILogger<AccountServices> logger;
     private readonly LoginHandoffTracker loginHandoffTracker;
@@ -44,6 +47,7 @@ public sealed class AccountServices
         RegistrationController registrationController,
         SharedSecretManager sharedSecretManager,
         LoginHandoffTracker loginHandoffTracker,
+        IOptions<AccountsOptions> config,
         ILogger<AccountServices> logger)
     {
         this.authenticator = authenticator;
@@ -53,6 +57,7 @@ public sealed class AccountServices
         this.registrationController = registrationController;
         this.sharedSecretManager = sharedSecretManager;
         this.loginHandoffTracker = loginHandoffTracker;
+        this.config = config.Value;
         this.logger = logger;
     }
 
@@ -96,6 +101,15 @@ public sealed class AccountServices
                 // Already logged in, log and reject.
                 logger.LogInformation("Rejected login for {Username}: already logged in.", username);
                 return AuthenticationResult.AlreadyLoggedIn;
+            }
+
+            // Reject if the server is at its concurrent player limit.
+            if (config.MaxPlayers > 0 && loginTracker.LoggedInAccountCount >= config.MaxPlayers)
+            {
+                logger.LogWarning(
+                    "Rejected login for {Username}: server is at capacity ({Count}/{MaxPlayers}).",
+                    username, loginTracker.LoggedInAccountCount, config.MaxPlayers);
+                return AuthenticationResult.ServerAtCapacity;
             }
 
             // Login successful.

--- a/src/Server/Accounts/Accounts/Services/AuthenticationResult.cs
+++ b/src/Server/Accounts/Accounts/Services/AuthenticationResult.cs
@@ -42,5 +42,11 @@ public enum AuthenticationResult
     ///     Too many failed attempts have been made to log into the account,
     ///     and login attempts are temporarily disabled for this account.
     /// </summary>
-    TooManyAttempts
+    TooManyAttempts,
+
+    /// <summary>
+    ///     The authentication was successful, but the server is at its
+    ///     concurrent player limit and the login was denied.
+    /// </summary>
+    ServerAtCapacity
 }

--- a/src/Server/ServerCore/Configuration/ServerConfiguration.cs
+++ b/src/Server/ServerCore/Configuration/ServerConfiguration.cs
@@ -215,4 +215,9 @@ public sealed class AccountsOptions
     ///     beyond which the handoff will be invalidated.
     /// </summary>
     public int HandoffPeriodSeconds { get; set; } = 30;
+
+    /// <summary>
+    ///     Maximum number of concurrently connected players, or 0 for no limit.
+    /// </summary>
+    public int MaxPlayers { get; set; } = 0;
 }

--- a/src/Server/ServerNetwork/Network/Rest/Accounts/AuthenticationRestService.cs
+++ b/src/Server/ServerNetwork/Network/Rest/Accounts/AuthenticationRestService.cs
@@ -56,6 +56,7 @@ public sealed class AuthenticationRestService
             { AuthenticationResult.Successful, 201 },
             { AuthenticationResult.AlreadyLoggedIn, 409 },
             { AuthenticationResult.TooManyAttempts, 429 },
+            { AuthenticationResult.ServerAtCapacity, 503 },
             { AuthenticationResult.Failed, 403 }
         };
 
@@ -70,6 +71,10 @@ public sealed class AuthenticationRestService
             {
                 AuthenticationResult.TooManyAttempts,
                 "The account is temporarily locked due to too many failed login attempts."
+            },
+            {
+                AuthenticationResult.ServerAtCapacity,
+                "The server is at capacity. Please try again later."
             },
             { AuthenticationResult.Failed, "Failed." }
         };

--- a/src/Server/SovereignServer/appsettings.json
+++ b/src/Server/SovereignServer/appsettings.json
@@ -32,7 +32,8 @@
       "MaxFailedLoginAttempts": 10,
       "LoginDenialPeriodSeconds": 1800,
       "MinimumPasswordLength": 8,
-      "HandoffPeriodSeconds": 30
+      "HandoffPeriodSeconds": 30,
+      "MaxPlayers": 0
     },
     "ScriptingOptions": {
       "ScriptDirectory": "Data/Scripts",


### PR DESCRIPTION
## Summary

Add a setting to appsettings.json on the server yo limit the number of concurrently connected players. A value of 0 means no limit. Default to no limit. Enforce the connection limit in the login REST service (deny login wirh an appropriate error if the limit is saturated). Ensure that the error is also properly handled in the client around LoginGui and its dependencies. Log a warning at the server whenever a login is rejected for this reason.

## Notes

- Trello card short ID: `P3GOnocF`
- Trello card: https://trello.com/c/P3GOnocF
- Implemented by sovereign-dev-agent (Kilo Code agent) in 1 attempt(s).
- Verified with 1 commit(s) and a clean build.