### PR TITLE
Add command for reloading entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### September
 
+#### 4 September 2026
+
+* Add new admin chat commands `/reloadentity` and `/reloadtemplate` to soft-reload entity script hooks.
+
 #### 3 September 2026
 
 * Add a server option to limit the number of concurrently connected players.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ prompt to download the latest game data files.
 | /reloadscript     | scriptName            | Admin only. Reloads the specific named script.        |
 | /loadnewscripts   |                       | Admin only. Loads any new scripts.                    |
 | /listscripts      |                       | Admin only. Lists all currently loaded scripts.       |
+| /reloadentity     | entityId              | Admin only. Reloads the script hooks of the given entity. |
+| /reloadtemplate   | templateRelId         | Admin only. Reloads all loaded entities of the given template. |
 
 ## Reporting Issues
 

--- a/docs/manual/creators/admin/admin_commands.md
+++ b/docs/manual/creators/admin/admin_commands.md
@@ -59,6 +59,36 @@ Reloads the specified script.
 
 Reloads all scripts, including any scripts which are not currently loaded.
 
+### /reloadentity
+
+**Usage:** `/reloadentity [entity_id]`
+
+**Parameters:**
+* `entity_id`: The hex-encoded entity ID of the entity to reload. If the ID is given with
+  no more than 12 hex digits, it is interpreted as an offset from the first persisted entity
+  ID `7fff000000000000` (e.g. `0` for entity ID `7fff000000000000`). Longer values are
+  interpreted as absolute entity IDs.
+
+Soft-reloads the given entity without unloading it. The entity's `OnEntityUnloaded` callback
+is invoked, followed by its `OnEntityLoaded` callback. The entity remains in memory, no
+entity unload or load events are fired, and the `OnEntityAdded`/`OnEntityRemoved` callbacks
+are not called. Only entities that are currently loaded can be reloaded; template entities
+and block entities are not eligible.
+
+### /reloadtemplate
+
+**Usage:** `/reloadtemplate [template_rel_id]`
+
+**Parameters:**
+* `template_rel_id`: The relative entity ID of the template entity (e.g. `0` for entity ID
+  `7ffe000000000000`), given as a decimal integer.
+
+Soft-reloads all currently loaded entities that have the given template. As with
+`/reloadentity`, each affected entity's `OnEntityUnloaded` callback is invoked followed by
+its `OnEntityLoaded` callback, and the entities remain in memory. The template entity itself
+is not reloaded, since template entities do not receive entity lifecycle callbacks. Callback
+hooks defined on the template entity are used for entities that do not define their own.
+
 ## World Editing
 
 ### /addblock

--- a/docs/manual/creators/scripting/callbacks/index.md
+++ b/docs/manual/creators/scripting/callbacks/index.md
@@ -34,3 +34,7 @@ in the [entity key-value store](#script-data-keyvaluedata):
 |`__OnEntityUnloaded_Function` |Name of the function to use as the EntityUnloaded callback.   |
 |`__OnEntityRemoved_Script`    |Name of the script that contains the EntityRemoved callback.  |
 |`__OnEntityRemoved_Function`  |Name of the function to use at the EntityRemoved callback.
+
+The EntityUnloaded and EntityLoaded callbacks can also be re-triggered for a loaded entity
+by an admin using the `/reloadentity` and `/reloadtemplate` commands without a full
+unload/load cycle.

--- a/src/Common/EngineCore/Events/EventIds.cs
+++ b/src/Common/EngineCore/Events/EventIds.cs
@@ -758,6 +758,19 @@ public enum EventId
     /// Associated details: IntEventDetails
     Server_Scripting_TimedCallback = 200703,
 
+    /// <summary>
+    ///     Requests that an entity be soft-reloaded by invoking its unload and load script hooks
+    ///     without unloading the entity.
+    /// </summary>
+    /// Associated details: EntityEventDetails
+    Server_Scripting_ReloadEntity = 200704,
+
+    /// <summary>
+    ///     Requests that all loaded instances of a template entity be soft-reloaded.
+    /// </summary>
+    /// Associated details: EntityEventDetails
+    Server_Scripting_ReloadTemplate = 200705,
+
     #endregion Server_Scripting
 
     #endregion Server

--- a/src/Server/ServerCore/Systems/Scripting/EntityScriptCallbacks.cs
+++ b/src/Server/ServerCore/Systems/Scripting/EntityScriptCallbacks.cs
@@ -36,22 +36,56 @@ public sealed class EntityScriptCallbacks
 
     private readonly Queue<ulong> entityAddQueue = new();
     private readonly Queue<ulong> entityLoadQueue = new();
+    private readonly Queue<ulong> entityReloadQueue = new();
     private readonly Queue<ulong> entityRemoveQueue = new();
     private readonly Dictionary<ulong, Task> entityTasks = new();
     private readonly Queue<(ulong, ulong)> entityTemplateUnloadQueue = new();
     private readonly Queue<ulong> entityUnloadQueue = new();
     private readonly ILogger<EntityScriptCallbacks> logger;
     private readonly ScriptManager scriptManager;
+    private readonly EntityTable entityTable;
 
     public EntityScriptCallbacks(EntityTable entityTable, IDataServices dataServices, ScriptManager scriptManager,
         ILogger<EntityScriptCallbacks> logger)
     {
+        this.entityTable = entityTable;
         this.dataServices = dataServices;
         this.scriptManager = scriptManager;
         this.logger = logger;
         entityTable.OnEntityAdded += OnEntityAdded;
         entityTable.OnEntityRemoved += OnEntityRemoved;
         entityTable.OnTemplateSet += OnTemplateSet;
+    }
+
+    /// <summary>
+    ///     Requests a soft reload of the given entity by enqueueing its unload and load callbacks.
+    /// </summary>
+    /// <param name="entityId">Entity ID.</param>
+    /// <returns>true if the entity was accepted for reload, false otherwise.</returns>
+    public bool RequestEntityReload(ulong entityId)
+    {
+        if (entityId is >= ExcludeRangeStart and < ExcludeRangeEnd) return false;
+        if (!entityTable.Exists(entityId)) return false;
+        entityReloadQueue.Enqueue(entityId);
+        return true;
+    }
+
+    /// <summary>
+    ///     Requests a soft reload of all loaded instances of the given template.
+    /// </summary>
+    /// <param name="templateId">Template entity ID.</param>
+    /// <returns>Number of instances enqueued for reload.</returns>
+    public int RequestTemplateReload(ulong templateId)
+    {
+        // Snapshot the live instance set so that changes during processing do not affect this request.
+        var count = 0;
+        foreach (var entityId in entityTable.GetInstancesOfTemplate(templateId))
+        {
+            entityReloadQueue.Enqueue(entityId);
+            count++;
+        }
+
+        return count;
     }
 
     /// <summary>
@@ -72,6 +106,33 @@ public sealed class EntityScriptCallbacks
             EntityConstants.LoadCallbackFunctionKey, EntityConstants.LoadCallbackName);
         ProcessCallbacks(entityUnloadQueue, EntityConstants.UnloadCallbackScriptKey,
             EntityConstants.UnloadCallbackFunctionKey, EntityConstants.UnloadCallbackName);
+        ProcessReloadCallbacks();
+    }
+
+    /// <summary>
+    ///     Processes pending soft reload callbacks by firing the unload hook followed by the load hook.
+    /// </summary>
+    private void ProcessReloadCallbacks()
+    {
+        while (entityReloadQueue.TryDequeue(out var entityId))
+        {
+            // Skip entities that were removed or unloaded since the reload was requested.
+            if (!entityTable.Exists(entityId)) continue;
+
+            // Fire the unload hook first, then the load hook. InvokeCallback chains tasks per entity ID,
+            // so the load hook will not run until the unload hook completes.
+            if (dataServices.TryGetEntityKeyValue(entityId, EntityConstants.UnloadCallbackScriptKey,
+                    out var unloadScript) &&
+                dataServices.TryGetEntityKeyValue(entityId, EntityConstants.UnloadCallbackFunctionKey,
+                    out var unloadFunction))
+                InvokeCallback(entityId, EntityConstants.UnloadCallbackName, unloadScript, unloadFunction);
+
+            if (dataServices.TryGetEntityKeyValue(entityId, EntityConstants.LoadCallbackScriptKey,
+                    out var loadScript) &&
+                dataServices.TryGetEntityKeyValue(entityId, EntityConstants.LoadCallbackFunctionKey,
+                    out var loadFunction))
+                InvokeCallback(entityId, EntityConstants.LoadCallbackName, loadScript, loadFunction);
+        }
     }
 
     /// <summary>

--- a/src/Server/ServerCore/Systems/Scripting/ScriptingController.cs
+++ b/src/Server/ServerCore/Systems/Scripting/ScriptingController.cs
@@ -62,6 +62,30 @@ public class ScriptingController(ScriptManager scriptManager, ILogger<ScriptingC
     }
 
     /// <summary>
+    ///     Requests that an entity be soft-reloaded by the Scripting system.
+    /// </summary>
+    /// <param name="eventSender">Event sender.</param>
+    /// <param name="entityId">Entity ID.</param>
+    public void ReloadEntity(IEventSender eventSender, ulong entityId)
+    {
+        var details = new EntityEventDetails { EntityId = entityId };
+        var ev = new Event(EventId.Server_Scripting_ReloadEntity, details);
+        eventSender.SendEvent(ev);
+    }
+
+    /// <summary>
+    ///     Requests that all loaded instances of a template be soft-reloaded.
+    /// </summary>
+    /// <param name="eventSender">Event sender.</param>
+    /// <param name="templateId">Template entity ID.</param>
+    public void ReloadTemplate(IEventSender eventSender, ulong templateId)
+    {
+        var details = new EntityEventDetails { EntityId = templateId };
+        var ev = new Event(EventId.Server_Scripting_ReloadTemplate, details);
+        eventSender.SendEvent(ev);
+    }
+
+    /// <summary>
     ///     Asynchronously invokes a function from a loaded script.
     /// </summary>
     /// <param name="scriptName">Script name.</param>

--- a/src/Server/ServerCore/Systems/Scripting/ScriptingSystem.cs
+++ b/src/Server/ServerCore/Systems/Scripting/ScriptingSystem.cs
@@ -59,6 +59,8 @@ internal class ScriptingSystem : ISystem
             EventId.Server_Scripting_Reload,
             EventId.Server_Scripting_LoadNew,
             EventId.Server_Scripting_TimedCallback,
+            EventId.Server_Scripting_ReloadEntity,
+            EventId.Server_Scripting_ReloadTemplate,
             EventId.Core_Tick,
             EventId.Core_Movement_EntityCollision,
             EventId.Core_Movement_ScheduledStop
@@ -124,6 +126,34 @@ internal class ScriptingSystem : ISystem
                     }
 
                     OnTimedCallback(details.LuaState, details.CallbackReference, details.ArgumentReference);
+                    break;
+                }
+
+                case EventId.Server_Scripting_ReloadEntity:
+                {
+                    if (ev.EventDetails is not EntityEventDetails reloadDetails)
+                    {
+                        logger.LogError("Received ReloadEntity event without details.");
+                        break;
+                    }
+
+                    if (!entityScriptCallbacks.RequestEntityReload(reloadDetails.EntityId))
+                        logger.LogError("Cannot reload entity {EntityId:X}: not an eligible in-memory entity.",
+                            reloadDetails.EntityId);
+                    break;
+                }
+
+                case EventId.Server_Scripting_ReloadTemplate:
+                {
+                    if (ev.EventDetails is not EntityEventDetails templateDetails)
+                    {
+                        logger.LogError("Received ReloadTemplate event without details.");
+                        break;
+                    }
+
+                    var count = entityScriptCallbacks.RequestTemplateReload(templateDetails.EntityId);
+                    logger.LogInformation("Requested reload of {Count} instances of template {TemplateId:X}.",
+                        count, templateDetails.EntityId);
                     break;
                 }
 

--- a/src/Server/ServerNetwork/Systems/ServerChat/AdminChatProcessor.cs
+++ b/src/Server/ServerNetwork/Systems/ServerChat/AdminChatProcessor.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Sovereign.EngineCore.Components;
@@ -80,10 +81,21 @@ public class AdminChatProcessor : IChatProcessor
     /// </summary>
     private const string ListScripts = "listscripts";
 
+    /// <summary>
+    ///     Command name for /reloadentity.
+    /// </summary>
+    private const string ReloadEntity = "reloadentity";
+
+    /// <summary>
+    ///     Command name for /reloadtemplate.
+    /// </summary>
+    private const string ReloadTemplate = "reloadtemplate";
+
     private readonly AdminTagCollection admins;
     private readonly BlockController blockController;
     private readonly IBlockServices blockServices;
     private readonly BlockTemplateNameComponentIndexer blockTemplateNames;
+    private readonly EntityTable entityTable;
     private readonly IEventSender eventSender;
     private readonly ServerChatInternalController internalController;
     private readonly ILogger<AdminChatProcessor> logger;
@@ -102,8 +114,9 @@ public class AdminChatProcessor : IChatProcessor
         NameComponentValidator nameValidator, PersistencePlayerServices persistencePlayerServices,
         LoggingUtil loggingUtil, NameComponentCollection names, WorldManagementController worldManagementController,
         IEventSender eventSender, BlockController blockController, IBlockServices blockServices,
-        BlockTemplateNameComponentIndexer blockTemplateNames, ILogger<AdminChatProcessor> logger,
-        ScriptingController scriptingController, ScriptingServices scriptingServices)
+        BlockTemplateNameComponentIndexer blockTemplateNames, EntityTable entityTable,
+        ILogger<AdminChatProcessor> logger, ScriptingController scriptingController,
+        ScriptingServices scriptingServices)
     {
         this.admins = admins;
         this.internalController = internalController;
@@ -118,6 +131,7 @@ public class AdminChatProcessor : IChatProcessor
         this.blockController = blockController;
         this.blockServices = blockServices;
         this.blockTemplateNames = blockTemplateNames;
+        this.entityTable = entityTable;
         this.logger = logger;
         this.scriptingController = scriptingController;
         this.scriptingServices = scriptingServices;
@@ -132,7 +146,9 @@ public class AdminChatProcessor : IChatProcessor
         new ChatCommand { Command = ReloadAllScripts, HelpSummary = "", IncludeInHelp = false },
         new ChatCommand { Command = ReloadScript, HelpSummary = "", IncludeInHelp = false },
         new ChatCommand { Command = LoadNewScripts, HelpSummary = "", IncludeInHelp = false },
-        new ChatCommand { Command = ListScripts, HelpSummary = "", IncludeInHelp = false }
+        new ChatCommand { Command = ListScripts, HelpSummary = "", IncludeInHelp = false },
+        new ChatCommand { Command = ReloadEntity, HelpSummary = "", IncludeInHelp = false },
+        new ChatCommand { Command = ReloadTemplate, HelpSummary = "", IncludeInHelp = false }
     };
 
     public void ProcessChat(string command, string message, ulong senderEntityId)
@@ -183,6 +199,14 @@ public class AdminChatProcessor : IChatProcessor
 
             case ListScripts:
                 OnListScripts(senderEntityId);
+                break;
+
+            case ReloadEntity:
+                OnReloadEntity(message, senderEntityId);
+                break;
+
+            case ReloadTemplate:
+                OnReloadTemplate(message, senderEntityId);
                 break;
         }
     }
@@ -443,5 +467,115 @@ public class AdminChatProcessor : IChatProcessor
         internalController.SendSystemMessage("Currently loaded scripts:", senderEntityId);
         foreach (var name in scriptingServices.GetLoadedScripts().Order())
             internalController.SendSystemMessage($"  - {name}", senderEntityId);
+    }
+
+    /// <summary>
+    ///     Handles the /reloadentity command.
+    /// </summary>
+    /// <param name="message">Remaining message.</param>
+    /// <param name="senderEntityId">Sender entity ID.</param>
+    private void OnReloadEntity(string message, ulong senderEntityId)
+    {
+        var args = message.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (args.Length != 1)
+        {
+            logger.LogWarning("{Player} used /reloadentity with bad parameters.",
+                loggingUtil.FormatEntity(senderEntityId));
+            internalController.SendSystemMessage("Usage: /reloadentity entity_id", senderEntityId);
+            return;
+        }
+
+        // Parse the hex-encoded entity ID. Short IDs are offsets from the first persisted entity ID.
+        var arg = args[0];
+        if (!ulong.TryParse(arg, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var parsed))
+        {
+            logger.LogWarning("{Player} used /reloadentity with a non-hex entity ID.",
+                loggingUtil.FormatEntity(senderEntityId));
+            internalController.SendSystemMessage("Entity ID must be hex-encoded.", senderEntityId);
+            return;
+        }
+
+        var entityId = arg.Length <= 12 ? EntityConstants.FirstPersistedEntityId + parsed : parsed;
+        if (!EntityUtil.IsRegularEntity(entityId))
+        {
+            logger.LogWarning("{Player} tried to reload non-regular entity {EntityId:X16}.",
+                loggingUtil.FormatEntity(senderEntityId), entityId);
+            internalController.SendSystemMessage("Entity ID must refer to a regular entity.", senderEntityId);
+            return;
+        }
+
+        if (!entityTable.Exists(entityId))
+        {
+            logger.LogWarning("{Player} tried to reload entity {EntityId:X16} which is not loaded.",
+                loggingUtil.FormatEntity(senderEntityId), entityId);
+            internalController.SendSystemMessage("Entity is not currently loaded.", senderEntityId);
+            return;
+        }
+
+        scriptingController.ReloadEntity(eventSender, entityId);
+        internalController.SendSystemMessage($"Entity {entityId:X16} will be reloaded.", senderEntityId);
+    }
+
+    /// <summary>
+    ///     Handles the /reloadtemplate command.
+    /// </summary>
+    /// <param name="message">Remaining message.</param>
+    /// <param name="senderEntityId">Sender entity ID.</param>
+    private void OnReloadTemplate(string message, ulong senderEntityId)
+    {
+        var args = message.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (args.Length != 1)
+        {
+            logger.LogWarning("{Player} used /reloadtemplate with bad parameters.",
+                loggingUtil.FormatEntity(senderEntityId));
+            internalController.SendSystemMessage("Usage: /reloadtemplate template_rel_id", senderEntityId);
+            return;
+        }
+
+        // Parse the decimal relative template entity ID, matching the /addblock convention.
+        ulong templateId;
+        try
+        {
+            templateId = EntityConstants.FirstTemplateEntityId + ulong.Parse(args[0]);
+        }
+        catch (Exception)
+        {
+            logger.LogWarning("{Player} used /reloadtemplate with a bad template_rel_id.",
+                loggingUtil.FormatEntity(senderEntityId));
+            internalController.SendSystemMessage("template_rel_id must correspond to a template entity.",
+                senderEntityId);
+            return;
+        }
+
+        if (!EntityUtil.IsTemplateEntity(templateId))
+        {
+            logger.LogWarning("{Player} tried to use a non-template entity as template entity.",
+                loggingUtil.FormatEntity(senderEntityId));
+            internalController.SendSystemMessage("template_rel_id must correspond to a template entity.",
+                senderEntityId);
+            return;
+        }
+
+        if (!entityTable.Exists(templateId))
+        {
+            logger.LogWarning("{Player} tried to reload template {TemplateId:X16} which is not loaded.",
+                loggingUtil.FormatEntity(senderEntityId), templateId);
+            internalController.SendSystemMessage("Template is not loaded.", senderEntityId);
+            return;
+        }
+
+        // Snapshot the live instance set so the count reported here matches the reload request.
+        var count = entityTable.GetInstancesOfTemplate(templateId).Count;
+        if (count == 0)
+        {
+            logger.LogWarning("{Player} tried to reload template {TemplateId:X16} which has no loaded instances.",
+                loggingUtil.FormatEntity(senderEntityId), templateId);
+            internalController.SendSystemMessage("No loaded entities have the given template.", senderEntityId);
+            return;
+        }
+
+        scriptingController.ReloadTemplate(eventSender, templateId);
+        internalController.SendSystemMessage(
+            count == 1 ? "1 entity will be reloaded." : $"{count} entities will be reloaded.", senderEntityId);
     }
 }


### PR DESCRIPTION
## Summary

Add new admin chat commands:
- /reloadentity id
- /reloadtemplate relId

These commands aoft-teload entities, meaning they leave the entity in memory (do not fire unload/load entity events) but call any unload script hooks followed by any load script hooks for the entity. Add and remove script hooks are not called. The first command reloads a single entity based on its hex-encoded entity ID (if length is 12 hex digits or less, treat as an offset and add to 0x7fff000000000000 to get the absolute entity ID. The second command reloads all currently loaded entities having the given template ID, which is given as a decimal offset from the first template ID (see EntityConstants). The admin should receive feedback for the command in the form of a system chat message.

## Notes

- Trello card short ID: `VaqqGOTx`
- Trello card: https://trello.com/c/VaqqGOTx
- Implemented by sovereign-dev-agent (Kilo Code agent) in 1 attempt(s).
- Verified with 1 commit(s) and a clean build.