### PR TITLE
Admin commands for working with key-value data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### September
 
+#### 6 September 2026
+
+* Add new admin chat commands `/getvalue`, `/setvalue`, `/getentityvalue`, and `/setentityvalue` for working with global and entity key-value data.
+
 #### 4 September 2026
 
 * Add new admin chat commands `/reloadentity` and `/reloadtemplate` to soft-reload entity script hooks.

--- a/docs/manual/creators/admin/admin_commands.md
+++ b/docs/manual/creators/admin/admin_commands.md
@@ -89,6 +89,68 @@ its `OnEntityLoaded` callback, and the entities remain in memory. The template e
 is not reloaded, since template entities do not receive entity lifecycle callbacks. Callback
 hooks defined on the template entity are used for entities that do not define their own.
 
+(chat-admin-key-value-data)=
+## Key-Value Data
+
+The key-value data stores described in the [Data Module](../scripting/api/data.md)
+can also be inspected and modified with the following admin commands. These
+commands follow the same rules as the scripting API: keys beginning with two
+underscores (`__`) are reserved for internal use by the engine and are
+read-only, and entity key-value stores are only available for loaded
+non-block entities that are not template entities.
+
+### /getvalue
+
+**Usage:** `/getvalue key`
+
+**Parameters:**
+* `key`: Key to look up in the global key-value store.
+
+Prints the value of the given key-value pair from the global key-value store, or an
+error message if the key does not exist.
+
+### /setvalue
+
+**Usage:** `/setvalue key [value]`
+
+**Parameters:**
+* `key`: Key of the global key-value pair to be modified or removed.
+* `value`: New value for the key. If omitted, the key is deleted.
+
+Sets the value of the given key-value pair in the global key-value store, creating
+the key if it does not already exist. If the value is omitted, the key is deleted
+from the global key-value store.
+
+### /getentityvalue
+
+**Usage:** `/getentityvalue entity_id key`
+
+**Parameters:**
+* `entity_id`: The hex-encoded entity ID of the entity, using the same convention as
+  `/reloadentity`.
+* `key`: Key to look up in the entity's key-value store.
+
+Prints the value of the given key-value pair from the given entity's key-value store.
+If the entity does not define the key itself but its template entity does, the
+inherited value is printed along with a note identifying the template entity from
+which it is inherited.
+
+### /setentityvalue
+
+**Usage:** `/setentityvalue entity_id key [value]`
+
+**Parameters:**
+* `entity_id`: The hex-encoded entity ID of the entity, using the same convention as
+  `/reloadentity`.
+* `key`: Key of the entity key-value pair to be modified or removed.
+* `value`: New value for the key. If omitted, the key is deleted.
+
+Sets the value of the given key-value pair on the given entity, creating the key if
+it does not already exist. The value is always written to the entity itself and never
+to its template entity. If the value is omitted, the key is deleted from the entity;
+if the entity's template entity defines the same key, the template's value will then
+be inherited again.
+
 ## World Editing
 
 ### /addblock

--- a/src/Common/EngineCore/Systems/Data/DataKeyConstraints.cs
+++ b/src/Common/EngineCore/Systems/Data/DataKeyConstraints.cs
@@ -21,7 +21,7 @@ namespace Sovereign.EngineCore.Systems.Data;
 /// <summary>
 ///     Constraints on Data system key-value keys that are shared by all write paths.
 /// </summary>
-public static class DataKeyConstraints
+internal static class DataKeyConstraints
 {
     /// <summary>
     ///     Prefix of keys that are read-only to scripts and admin chat commands.

--- a/src/Common/EngineCore/Systems/Data/DataKeyConstraints.cs
+++ b/src/Common/EngineCore/Systems/Data/DataKeyConstraints.cs
@@ -1,0 +1,40 @@
+// Sovereign Engine
+// Copyright (c) 2026 opticfluorine
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Sovereign.EngineCore.Systems.Data;
+
+/// <summary>
+///     Constraints on Data system key-value keys that are shared by all write paths.
+/// </summary>
+public static class DataKeyConstraints
+{
+    /// <summary>
+    ///     Prefix of keys that are read-only to scripts and admin chat commands.
+    /// </summary>
+    public const string ReadOnlyKeyPrefix = "__";
+
+    /// <summary>
+    ///     Determines whether a key is read-only to scripts and admin chat commands.
+    /// </summary>
+    /// <param name="key">Key.</param>
+    /// <returns>true if the key is read-only, false otherwise.</returns>
+    public static bool IsKeyReadOnly(string key)
+    {
+        return key.StartsWith(ReadOnlyKeyPrefix, StringComparison.Ordinal);
+    }
+}

--- a/src/Common/EngineCore/Systems/Data/DataServices.cs
+++ b/src/Common/EngineCore/Systems/Data/DataServices.cs
@@ -109,6 +109,13 @@ public interface IDataServices
     /// <param name="entityId">Entity ID.</param>
     /// <param name="data">Dictionary that will be cleared and filled with all key-value pairs.</param>
     void GetEntityData(ulong entityId, Dictionary<string, string> data);
+
+    /// <summary>
+    ///     Determines whether a key is read-only to scripts and admin chat commands.
+    /// </summary>
+    /// <param name="key">Key.</param>
+    /// <returns>true if the key is read-only, false otherwise.</returns>
+    bool IsKeyReadOnly(string key);
 }
 
 /// <summary>
@@ -173,5 +180,10 @@ internal class DataServices : IDataServices
     {
         data.Clear();
         entityStore.GetAllKeyValuePairs(entityId, data);
+    }
+
+    public bool IsKeyReadOnly(string key)
+    {
+        return DataKeyConstraints.IsKeyReadOnly(key);
     }
 }

--- a/src/Common/EngineCore/Systems/Data/DataServices.cs
+++ b/src/Common/EngineCore/Systems/Data/DataServices.cs
@@ -94,6 +94,16 @@ public interface IDataServices
     bool TryGetEntityKeyValue(ulong entityId, string key, [NotNullWhen(true)] out string? value);
 
     /// <summary>
+    ///     Gets a key-value pair for the given entity, checking only the entity's own store without
+    ///     the template entity fallback.
+    /// </summary>
+    /// <param name="entityId">Entity ID.</param>
+    /// <param name="key">Key.</param>
+    /// <param name="value">Value. Only meaningful if the method returns true.</param>
+    /// <returns>true if the key is found for the entity, false otherwise.</returns>
+    bool TryGetEntityKeyValueLocal(ulong entityId, string key, [NotNullWhen(true)] out string? value);
+
+    /// <summary>
     ///     Gets all key-value pairs for the given entity.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>
@@ -152,6 +162,11 @@ internal class DataServices : IDataServices
     public bool TryGetEntityKeyValue(ulong entityId, string key, [NotNullWhen(true)] out string? value)
     {
         return entityStore.TryGetValue(entityId, key, out value);
+    }
+
+    public bool TryGetEntityKeyValueLocal(ulong entityId, string key, [NotNullWhen(true)] out string? value)
+    {
+        return entityStore.TryGetValueLocal(entityId, key, out value);
     }
 
     public void GetEntityData(ulong entityId, Dictionary<string, string> data)

--- a/src/Common/EngineCore/Systems/Data/EntityKeyValueStore.cs
+++ b/src/Common/EngineCore/Systems/Data/EntityKeyValueStore.cs
@@ -80,6 +80,23 @@ internal class EntityKeyValueStore
     }
 
     /// <summary>
+    ///     Gets the value (if any) for the given entity ID and key, checking only the entity's own
+    ///     store without the template entity fallback.
+    /// </summary>
+    /// <param name="entityId">Entity ID.</param>
+    /// <param name="key">Key.</param>
+    /// <param name="value">Value. Only meaningful if method returns true.</param>
+    /// <returns>true if the key-value pair exists for the entity, false otherwise.</returns>
+    public bool TryGetValueLocal(ulong entityId, string key, [NotNullWhen(true)] out string? value)
+    {
+        if (keyValueStores.TryGetValue(entityId, out var store) && store.TryGetValue(key, out value))
+            return true;
+
+        value = null;
+        return false;
+    }
+
+    /// <summary>
     ///     Sets the value for the given entity ID and key.
     /// </summary>
     /// <param name="entityId">Entity ID.</param>

--- a/src/Server/ServerCore/Systems/Data/DataLuaLibrary.cs
+++ b/src/Server/ServerCore/Systems/Data/DataLuaLibrary.cs
@@ -170,7 +170,7 @@ public class DataLuaLibrary : ILuaLibrary, IDisposable
 
             var key = lua_tostring(luaState, -2);
 
-            if (DataKeyConstraints.IsKeyReadOnly(key))
+            if (dataServices.IsKeyReadOnly(key))
             {
                 scriptingServices.GetScriptLogger(mainState, logger)
                     .LogError("data.global[key]: key {Key} is read-only.", key);
@@ -349,7 +349,7 @@ public class DataLuaLibrary : ILuaLibrary, IDisposable
 
             var key = lua_tostring(luaState, -2);
 
-            if (DataKeyConstraints.IsKeyReadOnly(key))
+            if (dataServices.IsKeyReadOnly(key))
             {
                 scriptingServices.GetScriptLogger(mainState, logger)
                     .LogError("Entity KV set: key {Key} is read-only.", key);

--- a/src/Server/ServerCore/Systems/Data/DataLuaLibrary.cs
+++ b/src/Server/ServerCore/Systems/Data/DataLuaLibrary.cs
@@ -33,7 +33,6 @@ public class DataLuaLibrary : ILuaLibrary, IDisposable
     private const string LibraryName = "Data";
     private const long TableEntityIndex = 0;
 
-    private const string ReadOnlyKeyPrefix = "__";
     private readonly IDataController dataController;
     private readonly IDataServices dataServices;
 
@@ -171,7 +170,7 @@ public class DataLuaLibrary : ILuaLibrary, IDisposable
 
             var key = lua_tostring(luaState, -2);
 
-            if (IsKeyReadOnly(key))
+            if (DataKeyConstraints.IsKeyReadOnly(key))
             {
                 scriptingServices.GetScriptLogger(mainState, logger)
                     .LogError("data.global[key]: key {Key} is read-only.", key);
@@ -350,7 +349,7 @@ public class DataLuaLibrary : ILuaLibrary, IDisposable
 
             var key = lua_tostring(luaState, -2);
 
-            if (IsKeyReadOnly(key))
+            if (DataKeyConstraints.IsKeyReadOnly(key))
             {
                 scriptingServices.GetScriptLogger(mainState, logger)
                     .LogError("Entity KV set: key {Key} is read-only.", key);
@@ -409,16 +408,5 @@ public class DataLuaLibrary : ILuaLibrary, IDisposable
         }
 
         return 0;
-    }
-
-    /// <summary>
-    ///     Determines whether a key is read-only to scripts (i.e. special internal
-    ///     keys used by the engine such as the in-game clock).
-    /// </summary>
-    /// <param name="key">Key.</param>
-    /// <returns>true if read-only to scripts, false otherwise.</returns>
-    private bool IsKeyReadOnly(string key)
-    {
-        return key.StartsWith(ReadOnlyKeyPrefix);
     }
 }

--- a/src/Server/ServerNetwork/Systems/ServerChat/AdminChatProcessor.cs
+++ b/src/Server/ServerNetwork/Systems/ServerChat/AdminChatProcessor.cs
@@ -660,7 +660,7 @@ public class AdminChatProcessor : IChatProcessor
         }
 
         var key = args[0];
-        if (DataKeyConstraints.IsKeyReadOnly(key))
+        if (dataServices.IsKeyReadOnly(key))
         {
             logger.LogWarning("{Player} tried to set read-only key {Key} via /setvalue.",
                 loggingUtil.FormatEntity(senderEntityId), key);
@@ -730,7 +730,7 @@ public class AdminChatProcessor : IChatProcessor
         if (!ValidateEntityForDataCommand(args[0], senderEntityId, out var entityId)) return;
 
         var key = args[1];
-        if (DataKeyConstraints.IsKeyReadOnly(key))
+        if (dataServices.IsKeyReadOnly(key))
         {
             logger.LogWarning("{Player} tried to set read-only key {Key} on entity {EntityId:X16} via /setentityvalue.",
                 loggingUtil.FormatEntity(senderEntityId), key, entityId);

--- a/src/Server/ServerNetwork/Systems/ServerChat/AdminChatProcessor.cs
+++ b/src/Server/ServerNetwork/Systems/ServerChat/AdminChatProcessor.cs
@@ -29,6 +29,7 @@ using Sovereign.EngineCore.Events.Details;
 using Sovereign.EngineCore.Logging;
 using Sovereign.EngineCore.Player;
 using Sovereign.EngineCore.Systems.Block;
+using Sovereign.EngineCore.Systems.Data;
 using Sovereign.EngineCore.Systems.WorldManagement;
 using Sovereign.Persistence.Players;
 using Sovereign.ServerCore.Systems.Scripting;
@@ -91,10 +92,32 @@ public class AdminChatProcessor : IChatProcessor
     /// </summary>
     private const string ReloadTemplate = "reloadtemplate";
 
+    /// <summary>
+    ///     Command name for /getvalue.
+    /// </summary>
+    private const string GetValue = "getvalue";
+
+    /// <summary>
+    ///     Command name for /setvalue.
+    /// </summary>
+    private const string SetValue = "setvalue";
+
+    /// <summary>
+    ///     Command name for /getentityvalue.
+    /// </summary>
+    private const string GetEntityValue = "getentityvalue";
+
+    /// <summary>
+    ///     Command name for /setentityvalue.
+    /// </summary>
+    private const string SetEntityValue = "setentityvalue";
+
     private readonly AdminTagCollection admins;
     private readonly BlockController blockController;
     private readonly IBlockServices blockServices;
     private readonly BlockTemplateNameComponentIndexer blockTemplateNames;
+    private readonly IDataController dataController;
+    private readonly IDataServices dataServices;
     private readonly EntityTable entityTable;
     private readonly IEventSender eventSender;
     private readonly ServerChatInternalController internalController;
@@ -115,6 +138,7 @@ public class AdminChatProcessor : IChatProcessor
         LoggingUtil loggingUtil, NameComponentCollection names, WorldManagementController worldManagementController,
         IEventSender eventSender, BlockController blockController, IBlockServices blockServices,
         BlockTemplateNameComponentIndexer blockTemplateNames, EntityTable entityTable,
+        IDataController dataController, IDataServices dataServices,
         ILogger<AdminChatProcessor> logger, ScriptingController scriptingController,
         ScriptingServices scriptingServices)
     {
@@ -132,6 +156,8 @@ public class AdminChatProcessor : IChatProcessor
         this.blockServices = blockServices;
         this.blockTemplateNames = blockTemplateNames;
         this.entityTable = entityTable;
+        this.dataController = dataController;
+        this.dataServices = dataServices;
         this.logger = logger;
         this.scriptingController = scriptingController;
         this.scriptingServices = scriptingServices;
@@ -148,7 +174,11 @@ public class AdminChatProcessor : IChatProcessor
         new ChatCommand { Command = LoadNewScripts, HelpSummary = "", IncludeInHelp = false },
         new ChatCommand { Command = ListScripts, HelpSummary = "", IncludeInHelp = false },
         new ChatCommand { Command = ReloadEntity, HelpSummary = "", IncludeInHelp = false },
-        new ChatCommand { Command = ReloadTemplate, HelpSummary = "", IncludeInHelp = false }
+        new ChatCommand { Command = ReloadTemplate, HelpSummary = "", IncludeInHelp = false },
+        new ChatCommand { Command = GetValue, HelpSummary = "", IncludeInHelp = false },
+        new ChatCommand { Command = SetValue, HelpSummary = "", IncludeInHelp = false },
+        new ChatCommand { Command = GetEntityValue, HelpSummary = "", IncludeInHelp = false },
+        new ChatCommand { Command = SetEntityValue, HelpSummary = "", IncludeInHelp = false }
     };
 
     public void ProcessChat(string command, string message, ulong senderEntityId)
@@ -207,6 +237,22 @@ public class AdminChatProcessor : IChatProcessor
 
             case ReloadTemplate:
                 OnReloadTemplate(message, senderEntityId);
+                break;
+
+            case GetValue:
+                OnGetValue(message, senderEntityId);
+                break;
+
+            case SetValue:
+                OnSetValue(message, senderEntityId);
+                break;
+
+            case GetEntityValue:
+                OnGetEntityValue(message, senderEntityId);
+                break;
+
+            case SetEntityValue:
+                OnSetEntityValue(message, senderEntityId);
                 break;
         }
     }
@@ -577,5 +623,192 @@ public class AdminChatProcessor : IChatProcessor
         scriptingController.ReloadTemplate(eventSender, templateId);
         internalController.SendSystemMessage(
             count == 1 ? "1 entity will be reloaded." : $"{count} entities will be reloaded.", senderEntityId);
+    }
+
+    /// <summary>
+    ///     Handles the /getvalue command.
+    /// </summary>
+    /// <param name="message">Remaining message.</param>
+    /// <param name="senderEntityId">Sender entity ID.</param>
+    private void OnGetValue(string message, ulong senderEntityId)
+    {
+        var key = message.Trim();
+        if (key.Length == 0)
+        {
+            internalController.SendSystemMessage("Usage: /getvalue key", senderEntityId);
+            return;
+        }
+
+        if (dataServices.TryGetGlobal(key, out var value))
+            internalController.SendSystemMessage(value, senderEntityId);
+        else
+            internalController.SendSystemMessage("Key not found.", senderEntityId);
+    }
+
+    /// <summary>
+    ///     Handles the /setvalue command.
+    /// </summary>
+    /// <param name="message">Remaining message.</param>
+    /// <param name="senderEntityId">Sender entity ID.</param>
+    private void OnSetValue(string message, ulong senderEntityId)
+    {
+        var args = message.Split(' ', 2, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (args.Length == 0)
+        {
+            internalController.SendSystemMessage("Usage: /setvalue key [value]", senderEntityId);
+            return;
+        }
+
+        var key = args[0];
+        if (DataKeyConstraints.IsKeyReadOnly(key))
+        {
+            logger.LogWarning("{Player} tried to set read-only key {Key} via /setvalue.",
+                loggingUtil.FormatEntity(senderEntityId), key);
+            internalController.SendSystemMessage("Key is read-only.", senderEntityId);
+            return;
+        }
+
+        if (args.Length == 1)
+        {
+            dataController.RemoveGlobalSync(key);
+            internalController.SendSystemMessage($"Key {key} deleted.", senderEntityId);
+            return;
+        }
+
+        dataController.SetGlobalSync(key, args[1]);
+        internalController.SendSystemMessage($"Key {key} set to {args[1]}.", senderEntityId);
+    }
+
+    /// <summary>
+    ///     Handles the /getentityvalue command.
+    /// </summary>
+    /// <param name="message">Remaining message.</param>
+    /// <param name="senderEntityId">Sender entity ID.</param>
+    private void OnGetEntityValue(string message, ulong senderEntityId)
+    {
+        var args = message.Split(' ', 2, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (args.Length != 2)
+        {
+            internalController.SendSystemMessage("Usage: /getentityvalue entity_id key", senderEntityId);
+            return;
+        }
+
+        if (!ValidateEntityForDataCommand(args[0], senderEntityId, out var entityId)) return;
+
+        var key = args[1];
+        if (dataServices.TryGetEntityKeyValueLocal(entityId, key, out var value))
+        {
+            internalController.SendSystemMessage(value, senderEntityId);
+            return;
+        }
+
+        if (entityTable.TryGetTemplate(entityId, out var templateId) &&
+            dataServices.TryGetEntityKeyValueLocal(templateId, key, out value))
+        {
+            internalController.SendSystemMessage($"{value} (inherited from template {templateId:X16})",
+                senderEntityId);
+            return;
+        }
+
+        internalController.SendSystemMessage("Key not found.", senderEntityId);
+    }
+
+    /// <summary>
+    ///     Handles the /setentityvalue command.
+    /// </summary>
+    /// <param name="message">Remaining message.</param>
+    /// <param name="senderEntityId">Sender entity ID.</param>
+    private void OnSetEntityValue(string message, ulong senderEntityId)
+    {
+        var args = message.Split(' ', 3, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (args.Length < 2)
+        {
+            internalController.SendSystemMessage("Usage: /setentityvalue entity_id key [value]", senderEntityId);
+            return;
+        }
+
+        if (!ValidateEntityForDataCommand(args[0], senderEntityId, out var entityId)) return;
+
+        var key = args[1];
+        if (DataKeyConstraints.IsKeyReadOnly(key))
+        {
+            logger.LogWarning("{Player} tried to set read-only key {Key} on entity {EntityId:X16} via /setentityvalue.",
+                loggingUtil.FormatEntity(senderEntityId), key, entityId);
+            internalController.SendSystemMessage("Key is read-only.", senderEntityId);
+            return;
+        }
+
+        if (args.Length == 2)
+        {
+            dataController.RemoveEntityKeyValueSync(entityId, key);
+            internalController.SendSystemMessage($"Key {key} deleted on entity {entityId:X16}.", senderEntityId);
+            return;
+        }
+
+        dataController.SetEntityKeyValueSync(entityId, key, args[2]);
+        internalController.SendSystemMessage($"Key {key} on entity {entityId:X16} set to {args[2]}.", senderEntityId);
+    }
+
+    /// <summary>
+    ///     Parses a hex-encoded entity ID, interpreting short IDs as offsets from the first persisted
+    ///     entity ID.
+    /// </summary>
+    /// <param name="arg">Hex-encoded entity ID argument.</param>
+    /// <param name="entityId">Parsed entity ID, or zero if the method returns false.</param>
+    /// <returns>true if the entity ID was parsed, false otherwise.</returns>
+    private bool TryParseEntityId(string arg, out ulong entityId)
+    {
+        if (!ulong.TryParse(arg, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var parsed))
+        {
+            entityId = 0;
+            return false;
+        }
+
+        entityId = arg.Length <= 12 ? EntityConstants.FirstPersistedEntityId + parsed : parsed;
+        return true;
+    }
+
+    /// <summary>
+    ///     Validates that the given entity ID argument refers to a loaded regular entity that is
+    ///     eligible for key-value data commands, sending a system message to the sender if not.
+    /// </summary>
+    /// <param name="arg">Hex-encoded entity ID argument.</param>
+    /// <param name="senderEntityId">Sender entity ID.</param>
+    /// <param name="entityId">Parsed entity ID, or zero if the method returns false.</param>
+    /// <returns>true if the entity is valid for key-value data commands, false otherwise.</returns>
+    private bool ValidateEntityForDataCommand(string arg, ulong senderEntityId, out ulong entityId)
+    {
+        if (!TryParseEntityId(arg, out entityId))
+        {
+            internalController.SendSystemMessage("Entity ID must be hex-encoded.", senderEntityId);
+            return false;
+        }
+
+        if (entityId is >= EntityConstants.FirstBlockEntityId and <= EntityConstants.LastBlockEntityId)
+        {
+            logger.LogWarning("{Player} used a key-value data command on block entity {EntityId:X16}.",
+                loggingUtil.FormatEntity(senderEntityId), entityId);
+            internalController.SendSystemMessage("Entity key-value data cannot be used on block entities.",
+                senderEntityId);
+            return false;
+        }
+
+        if (!EntityUtil.IsRegularEntity(entityId))
+        {
+            logger.LogWarning("{Player} used a key-value data command on non-regular entity {EntityId:X16}.",
+                loggingUtil.FormatEntity(senderEntityId), entityId);
+            internalController.SendSystemMessage("Entity ID must refer to a regular entity.", senderEntityId);
+            return false;
+        }
+
+        if (!entityTable.Exists(entityId))
+        {
+            logger.LogWarning("{Player} used a key-value data command on entity {EntityId:X16} which is not loaded.",
+                loggingUtil.FormatEntity(senderEntityId), entityId);
+            internalController.SendSystemMessage("Entity is not currently loaded.", senderEntityId);
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Test/TestEngineCore/Systems/Data/TestDataKeyConstraints.cs
+++ b/src/Test/TestEngineCore/Systems/Data/TestDataKeyConstraints.cs
@@ -1,0 +1,36 @@
+// Sovereign Engine
+// Copyright (c) 2026 opticfluorine
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Xunit;
+
+namespace Sovereign.EngineCore.Systems.Data;
+
+/// <summary>
+///     Unit tests for DataKeyConstraints.
+/// </summary>
+public class TestDataKeyConstraints
+{
+    [Theory]
+    [InlineData("__Internal", true)]
+    [InlineData("__", true)]
+    [InlineData("MyKey", false)]
+    [InlineData("_MyKey", false)]
+    [InlineData("", false)]
+    public void IsKeyReadOnly_ChecksPrefix(string key, bool expected)
+    {
+        Assert.Equal(expected, DataKeyConstraints.IsKeyReadOnly(key));
+    }
+}

--- a/src/Test/TestEngineCore/Systems/Data/TestEntityKeyValueStore.cs
+++ b/src/Test/TestEngineCore/Systems/Data/TestEntityKeyValueStore.cs
@@ -1,0 +1,74 @@
+// Sovereign Engine
+// Copyright (c) 2026 opticfluorine
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Moq;
+using Sovereign.EngineCore.Entities;
+using Sovereign.EngineCore.Events;
+using Xunit;
+
+namespace Sovereign.EngineCore.Systems.Data;
+
+/// <summary>
+///     Unit tests for EntityKeyValueStore.
+/// </summary>
+public class TestEntityKeyValueStore
+{
+    private const ulong TemplateId = 0x7ffe000000000001;
+    private const ulong EntityId = 0x7fff000000000001;
+
+    private readonly EntityTable entityTable = new();
+    private readonly EntityKeyValueStore store;
+
+    public TestEntityKeyValueStore()
+    {
+        var mockEventSender = new Mock<IEventSender>();
+        var internalController = new DataInternalController(mockEventSender.Object);
+        store = new EntityKeyValueStore(entityTable, mockEventSender.Object, internalController);
+
+        // Set up a template entity with one instance.
+        entityTable.Add(TemplateId, 0, false, false, false);
+        entityTable.Add(EntityId, TemplateId, false, false, false);
+        entityTable.UpdateAllEntities();
+    }
+
+    [Fact]
+    public void TryGetValueLocal_ReturnsValueForEntity()
+    {
+        store.SetValue(EntityId, "MyKey", "MyValue");
+
+        Assert.True(store.TryGetValueLocal(EntityId, "MyKey", out var value));
+        Assert.Equal("MyValue", value);
+    }
+
+    [Fact]
+    public void TryGetValueLocal_ReturnsFalseForMissingKey()
+    {
+        Assert.False(store.TryGetValueLocal(EntityId, "MyKey", out var value));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryGetValueLocal_DoesNotFallBackToTemplate()
+    {
+        store.SetValue(TemplateId, "MyKey", "TemplateValue");
+
+        Assert.False(store.TryGetValueLocal(EntityId, "MyKey", out _));
+
+        // The inheriting lookup still falls back to the template.
+        Assert.True(store.TryGetValue(EntityId, "MyKey", out var value));
+        Assert.Equal("TemplateValue", value);
+    }
+}


### PR DESCRIPTION
## Summary

Add new admin chat commands:
- /getvalue key
- /setvalue key value
- /getentityvalue entityId key
- /setentityvalue entityId key value

These commands allow an admin to read and write global (first two commands) and entity (last two commands) key-value data. See DataSystem and its Controller and Services classes. The entity commands should only work for currently loaded entities. The same restrictions for writing keys should apply as for the scripting API for the Data system, in particular there is a restriction on writing to keys with a specific prefix. For getentitydata, if the entity does not have the key but its template entity does, show the value for the template entity and indicate that it is inherited. Setting entity data modifies the value for the specific entity, never for the template from which it inherits. Setting a key with no value should delete the key.

## Testing

- full Debug rebuild of Sovereign.sln with 0 warnings and 0 errors;

## Notes

- Trello card short ID: `E5tFZvtC`
- Trello card: https://trello.com/c/E5tFZvtC
- Implemented by sovereign-dev-agent (Kilo Code agent) in 1 attempt(s).
- Verified with 1 commit(s) and a clean build.