### PR TITLE
Create local component value when modifying a component inherited from template

### DIFF
--- a/src/Common/EngineCore/Components/BaseComponentCollection.cs
+++ b/src/Common/EngineCore/Components/BaseComponentCollection.cs
@@ -39,7 +39,9 @@ namespace Sovereign.EngineCore.Components;
 /// </list>
 /// Operations are enqueued with respect to the current state of the component;
 /// for example, RemoveComponent() cannot be called to remove a component that
-/// is currently enqueued for addition.
+/// is currently enqueued for addition. Modifying a component inherited from a
+/// template entity creates a local copy of the component value for the entity;
+/// the template value is left unchanged.
 /// <typeparam name="T">Component value type.</typeparam>
 public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSource<T>, IComponentRemover
     where T : notnull
@@ -48,6 +50,12 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     ///     Internal operation buffer size.
     /// </summary>
     private const int OperationBufferSize = 1024;
+
+    /// <summary>
+    ///     Sentinel component index indicating that a pending modification applies to an
+    ///     entity that inherits its component value from its template entity.
+    /// </summary>
+    private const int InheritedComponentIndex = -1;
 
     private readonly EntityTable entityTable;
 
@@ -348,8 +356,12 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     ///     Enqueues the modification of the component associated with the given entity.
     /// </summary>
     /// Note that the component must already exist and be associated with the given
-    /// entity; it is not sufficient to first make the corresponding call to
-    /// AddComponent. If the component is not associated, this method has no effect.
+    /// entity, either directly or via template inheritance; it is not sufficient to
+    /// first make the corresponding call to AddComponent. If the component is not
+    /// associated with the entity, this method has no effect. If the component value
+    /// is inherited from the entity's template entity, a local copy of the template
+    /// value is created for the entity when the modification is applied, and the
+    /// template value is left unchanged.
     /// <param name="entityId">Entity ID.</param>
     /// <param name="operation">Operation to perform on the component.</param>
     /// <param name="adjustment">Adjustment value.</param>
@@ -358,8 +370,16 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
     /// </exception>
     public void ModifyComponent(ulong entityId, ComponentOperation operation, T adjustment)
     {
-        /* Ensure that the entity has an associated component. */
-        if (!entityToComponentMap.TryGetValue(entityId, out var componentIndex)) return;
+        /* Ensure that the entity has an associated component, either directly or via
+           template inheritance. */
+        var isInherited = false;
+        if (!entityToComponentMap.TryGetValue(entityId, out var componentIndex))
+        {
+            if (!(entityTable.TryGetTemplate(entityId, out var templateId) &&
+                    HasComponentForEntity(templateId)))
+                return;
+            isInherited = true;
+        }
 
         /* Ensure that the operation is supported by this component. */
         if (!operators.ContainsKey(operation))
@@ -369,7 +389,7 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
         var pendingModify = new PendingModify
         {
             EntityId = entityId,
-            ComponentIndex = componentIndex,
+            ComponentIndex = isInherited ? InheritedComponentIndex : componentIndex,
             ComponentOperation = operation,
             Adjustment = adjustment
         };
@@ -635,9 +655,10 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
             for (var i = 0; i < queue.Count; ++i)
             {
                 ref var pendingModify = ref queue[i];
-                var transformed = op(components[pendingModify.ComponentIndex],
+                if (!TryResolveComponentIndexForModify(ref pendingModify, out var componentIndex)) continue;
+                var transformed = op(components[componentIndex],
                     pendingModify.Adjustment);
-                components[pendingModify.ComponentIndex] = transformed;
+                components[componentIndex] = transformed;
                 pendingModifyEvents.Add(pendingModify.EntityId);
             }
 
@@ -646,6 +667,33 @@ public class BaseComponentCollection<T> : IComponentUpdater, IComponentEventSour
         }
 
         hasModifications = false;
+    }
+
+    /// <summary>
+    ///     Resolves the component buffer index to which a pending modification applies, creating a
+    ///     local copy of the inherited template value for the entity if needed.
+    /// </summary>
+    /// <param name="pendingModify">Pending modification.</param>
+    /// <param name="componentIndex">
+    ///     Component buffer index to which the modification applies. Only meaningful if this
+    ///     method returns true.
+    /// </param>
+    /// <returns>true if a component index was resolved, false otherwise.</returns>
+    private bool TryResolveComponentIndexForModify(ref PendingModify pendingModify, out int componentIndex)
+    {
+        if (pendingModify.ComponentIndex != InheritedComponentIndex)
+        {
+            componentIndex = pendingModify.ComponentIndex;
+            return true;
+        }
+
+        if (entityToComponentMap.TryGetValue(pendingModify.EntityId, out componentIndex)) return true;
+
+        var maybeValue = GetComponentForEntity(pendingModify.EntityId);
+        if (!maybeValue.HasValue) return false;
+        componentIndex = AddComponentToBuffer(maybeValue.Value);
+        RegisterIndices(componentIndex, pendingModify.EntityId);
+        return true;
     }
 
     /// <summary>

--- a/src/Test/TestEngineCore/Components/TestBaseComponentCollection.cs
+++ b/src/Test/TestEngineCore/Components/TestBaseComponentCollection.cs
@@ -21,11 +21,14 @@ namespace Sovereign.EngineCore.Components;
 
 public class TestBaseComponentCollection
 {
+    private const ulong TemplateId = 0x7ffe000000000001;
+    private const ulong EntityId = 0x7fff000000000001;
+
+    private readonly EntityTable entityTable = new();
     private readonly BaseComponentCollection<int> collection;
 
     public TestBaseComponentCollection()
     {
-        var entityTable = new EntityTable();
         var entityNotifier = new EntityNotifier();
         var componentManager = new ComponentManager(entityNotifier);
         collection =
@@ -363,6 +366,104 @@ public class TestBaseComponentCollection
 
         Assert.False(collection.HasComponentForEntity(entityId1));
         Assert.False(collection.HasComponentForEntity(entityId2));
+    }
+
+    [Fact]
+    public void ModifyComponent_Add_CreatesLocalComponentFromTemplateValue()
+    {
+        RegisterTemplateInheritance();
+        collection.AddComponent(TemplateId, 42);
+        collection.ApplyComponentUpdates();
+
+        collection.ModifyComponent(EntityId, ComponentOperation.Add, 10);
+        collection.ApplyComponentUpdates();
+
+        Assert.Equal(52, collection[EntityId]);
+        Assert.True(collection.HasLocalComponentForEntity(EntityId));
+        Assert.Equal(42, collection[TemplateId]);
+    }
+
+    [Fact]
+    public void ModifyComponent_Set_CreatesLocalComponentFromTemplateValue()
+    {
+        RegisterTemplateInheritance();
+        collection.AddComponent(TemplateId, 42);
+        collection.ApplyComponentUpdates();
+
+        collection.ModifyComponent(EntityId, ComponentOperation.Set, 7);
+        collection.ApplyComponentUpdates();
+
+        Assert.Equal(7, collection[EntityId]);
+        Assert.True(collection.HasLocalComponentForEntity(EntityId));
+        Assert.Equal(42, collection[TemplateId]);
+    }
+
+    [Fact]
+    public void ModifyComponent_MultipleModificationsInTick_CreateSingleLocalComponent()
+    {
+        RegisterTemplateInheritance();
+        collection.AddComponent(TemplateId, 42);
+        collection.ApplyComponentUpdates();
+
+        collection.ModifyComponent(EntityId, ComponentOperation.Add, 3);
+        collection.ModifyComponent(EntityId, ComponentOperation.Multiply, 2);
+        collection.ApplyComponentUpdates();
+
+        Assert.Equal(90, collection[EntityId]);
+        Assert.True(collection.HasLocalComponentForEntity(EntityId));
+        Assert.Equal(42, collection[TemplateId]);
+    }
+
+    [Fact]
+    public void ModifyComponent_FiresModifiedEventForLocalCopy()
+    {
+        RegisterTemplateInheritance();
+        collection.AddComponent(TemplateId, 42);
+        collection.ApplyComponentUpdates();
+
+        var modifiedEntityIds = new List<ulong>();
+        var modifiedValues = new List<int>();
+        collection.OnComponentModified += (entityId, value) =>
+        {
+            modifiedEntityIds.Add(entityId);
+            modifiedValues.Add(value);
+        };
+
+        collection.ModifyComponent(EntityId, ComponentOperation.Set, 7);
+        collection.ApplyComponentUpdates();
+
+        Assert.Equal(EntityId, Assert.Single(modifiedEntityIds));
+        Assert.Equal(7, Assert.Single(modifiedValues));
+    }
+
+    [Fact]
+    public void ModifyComponent_NoEffectIfNoComponent()
+    {
+        ulong entityId = 1;
+
+        collection.ModifyComponent(entityId, ComponentOperation.Add, 10);
+        collection.ApplyComponentUpdates();
+
+        Assert.False(collection.HasComponentForEntity(entityId));
+    }
+
+    [Fact]
+    public void ModifyComponent_NoEffectIfTemplateLacksComponent()
+    {
+        RegisterTemplateInheritance();
+
+        collection.ModifyComponent(EntityId, ComponentOperation.Add, 10);
+        collection.ApplyComponentUpdates();
+
+        Assert.False(collection.HasLocalComponentForEntity(EntityId));
+        Assert.False(collection.HasComponentForEntity(EntityId));
+    }
+
+    private void RegisterTemplateInheritance()
+    {
+        entityTable.Add(TemplateId, 0, false, false, false);
+        entityTable.Add(EntityId, TemplateId, false, false, false);
+        entityTable.UpdateAllEntities();
     }
 
     private class DummyComponentCollection<T> : BaseComponentCollection<T> where T : notnull


### PR DESCRIPTION
## Summary

@file src/EngineCore/Components/BaseComponentCollection.cs in its ApplyModifications method around line 627 currently is a no-op if the entity is inheriting its component value from its template entity. The correct behavior should be to create a local copy of the template component value for the affected entity if the value of the inheriting entity is modified.

## Testing

- Full rebuild of Sovereign.sln in Debug configuration succeeded with 0
- full clean rebuild of Sovereign.sln (Debug) with 0 warnings and 0
- Full rebuild of Sovereign.sln in Debug configuration with zero
- full Debug rebuild of Sovereign.sln with 0 warnings and 0 errors;

## Notes

- Trello card short ID: `f5Dc7ioG`
- Trello card: https://trello.com/c/f5Dc7ioG
- Implemented by sovereign-dev-agent (Kilo Code agent) in 1 attempt(s).
- Verified with 1 commit(s) and a clean build.